### PR TITLE
(maint) Add internal_list key to MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2,7 +2,7 @@
   "version": 1,
   "file_format": "This MAINTAINERS file format is described at https://github.com/puppetlabs/maintainers",
   "issues": "RE Project for now.",
-  "internal_list": "https://groups.google.com/a/puppet.com/forum/?hl=en#!forum/discuss-pl-build-tools-vanagon-maintainers",
+  "internal_list": "https://groups.google.com/a/puppet.com/forum/?hl=en#!forum/discuss-release-engineering",
   "people": [
     {
       "github": "stahnma",

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2,6 +2,7 @@
   "version": 1,
   "file_format": "This MAINTAINERS file format is described at https://github.com/puppetlabs/maintainers",
   "issues": "RE Project for now.",
+  "internal_list": "https://groups.google.com/a/puppet.com/forum/?hl=en#!forum/discuss-pl-build-tools-vanagon-maintainers",
   "people": [
     {
       "github": "stahnma",


### PR DESCRIPTION
This change adds a reference to the Google group the maintainers are associated with.