### PR TITLE
Solaris 10 final fixes for u8 template

### DIFF
--- a/configs/components/binutils.rb
+++ b/configs/components/binutils.rb
@@ -43,7 +43,7 @@ component "binutils" do |pkg, settings, platform|
 
   # Build Commands
   pkg.configure do
-    if platform.is_cross_compiled_linux?
+    if platform.is_cross_compiled?
       # --with-sysroot is an undocumented configure option in binutils
       # but necessary to avoid "ld: this linker was not configured to
       # use sysroots" when doing subsequent builds (e.g, pl-gcc)

--- a/configs/components/gcc.rb
+++ b/configs/components/gcc.rb
@@ -234,7 +234,7 @@ component "gcc" do |pkg, settings, platform|
     configure_command << " --target=#{settings[:platform_triple]} \
       --with-gnu-as \
       --with-as=#{settings[:bindir]}/as \
-      --without-gnu-ld \
+      --with-gnu-ld \
       --with-ld=#{settings[:bindir]}/ld"
 
       if platform.architecture.downcase == 'sparc'

--- a/configs/projects/pl-binutils.rb
+++ b/configs/projects/pl-binutils.rb
@@ -18,7 +18,7 @@ project "pl-binutils" do |proj|
 
   if platform.is_solaris? && platform.os_version == "10"
     proj.version "2.27"
-    proj.release "1"
+    proj.release "2"
   end
 
   # Platform specific

--- a/configs/projects/pl-gcc.rb
+++ b/configs/projects/pl-gcc.rb
@@ -12,7 +12,7 @@ project "pl-gcc" do |proj|
     proj.release "11"
   else
     proj.version "4.8.2"
-    proj.release "8"
+    proj.release "9"
   end
 
   if platform.is_cross_compiled_linux?


### PR DESCRIPTION
This is the final change I needed to make to pl-build-tools to generate packages which I can then use to build puppet-agent using the u8 solaris 10 template.