### PR TITLE
Fedora 25 platform configs and pl-gcc

### DIFF
--- a/configs/components/gcc.rb
+++ b/configs/components/gcc.rb
@@ -1,6 +1,6 @@
 component "gcc" do |pkg, settings, platform|
   # Source-Related Metadata
-  if platform.name =~ /fedora-f24/
+  if platform.name =~ /fedora-f24|fedora-f25/
     pkg.version "6.1.0"
     pkg.md5sum "8d04cbdfddcfad775fdbc5e112af2690"
   elsif platform.is_aix? || platform.architecture == "s390x" || platform.architecture =~ /arm/

--- a/configs/platforms/fedora-f25-i386.rb
+++ b/configs/platforms/fedora-f25-i386.rb
@@ -1,0 +1,10 @@
+platform "fedora-f25-i386" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc make rpmdevtools rpm-libs"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-25.noarch.rpm"
+  plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
+  plat.vmpooler_template "fedora-25-i386"
+end

--- a/configs/platforms/fedora-f25-x86_64.rb
+++ b/configs/platforms/fedora-f25-x86_64.rb
@@ -1,0 +1,10 @@
+platform "fedora-f25-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc make rpmdevtools rpm-libs"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-25.noarch.rpm"
+  plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
+  plat.vmpooler_template "fedora-25-x86_64"
+end

--- a/configs/projects/pl-gcc.rb
+++ b/configs/projects/pl-gcc.rb
@@ -4,7 +4,7 @@ project "pl-gcc" do |proj|
 
   proj.description "Puppet Labs GCC"
 
-  if platform.name =~ /fedora-f24/
+  if platform.name =~ /fedora-f24|fedora-f25/
     proj.version "6.1.0"
     proj.release "0"
   elsif platform.is_aix? || platform.architecture == "s390x" || platform.architecture =~ /arm/


### PR DESCRIPTION
We're using gcc 6.1 as 4.8.2 doesn't compile cleanly using fedora 25's system gcc, and as a new platform anyway we may as well start with the latest we're aiming to migrate to. Builds pass and generate expected packages.