### PR TITLE
Ubuntu 16.10 platform config and pl-gcc

### DIFF
--- a/configs/components/gcc.rb
+++ b/configs/components/gcc.rb
@@ -1,6 +1,6 @@
 component "gcc" do |pkg, settings, platform|
   # Source-Related Metadata
-  if platform.name =~ /fedora-f24|fedora-f25/
+  if platform.name =~ /fedora-f24|fedora-f25|ubuntu-16\.10/
     pkg.version "6.1.0"
     pkg.md5sum "8d04cbdfddcfad775fdbc5e112af2690"
   elsif platform.is_aix? || platform.architecture == "s390x" || platform.architecture =~ /arm/

--- a/configs/platforms/ubuntu-16.10-amd64.rb
+++ b/configs/platforms/ubuntu-16.10-amd64.rb
@@ -1,0 +1,12 @@
+platform "ubuntu-16.10-amd64" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "yakkety"
+
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vmpooler_template "ubuntu-1610-x86_64"
+  plat.output_dir File.join("deb", plat.get_codename)
+end

--- a/configs/platforms/ubuntu-16.10-i386.rb
+++ b/configs/platforms/ubuntu-16.10-i386.rb
@@ -1,0 +1,12 @@
+platform "ubuntu-16.10-i386" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "yakkety"
+
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vmpooler_template "ubuntu-1610-i386"
+  plat.output_dir File.join("deb", plat.get_codename)
+end

--- a/configs/projects/pl-gcc.rb
+++ b/configs/projects/pl-gcc.rb
@@ -4,7 +4,7 @@ project "pl-gcc" do |proj|
 
   proj.description "Puppet Labs GCC"
 
-  if platform.name =~ /fedora-f24|fedora-f25/
+  if platform.name =~ /fedora-f24|fedora-f25|ubuntu-16\.10/
     proj.version "6.1.0"
     proj.release "0"
   elsif platform.is_aix? || platform.architecture == "s390x" || platform.architecture =~ /arm/


### PR DESCRIPTION
Like Fedora 25, we're using gcc 6.1.0 since this is a new platform. Build tested and working.