### PR TITLE
(BUILD-61) Work-around Cisco IOS XR networking stack bug

### DIFF
--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -15,6 +15,10 @@ component "boost" do |pkg, settings, platform|
     pkg.apply_patch 'resources/patches/boost/solaris-10-boost-build.patch'
   end
 
+  if platform.is_cisco_wrlinux?
+    pkg.apply_patch 'resources/patches/boost/no-fionbio.patch'
+  end
+
   # Package Dependency Metadata
 
   # Build Requirements

--- a/resources/patches/boost/no-fionbio.patch
+++ b/resources/patches/boost/no-fionbio.patch
@@ -1,0 +1,127 @@
+From 2c0439ce3a11433a87321bc943ba0c05234c1c11 Mon Sep 17 00:00:00 2001
+From: Michael Smith <michael.smith@puppet.com>
+Date: Tue, 31 Jan 2017 23:23:53 +0000
+Subject: [PATCH] Patch for Cisco IOS XR
+
+---
+ boost/asio/detail/impl/descriptor_ops.ipp | 15 ---------------
+ boost/asio/detail/impl/socket_ops.ipp     | 15 ++-------------
+ 2 files changed, 2 insertions(+), 28 deletions(-)
+
+diff --git a/boost/asio/detail/impl/descriptor_ops.ipp b/boost/asio/detail/impl/descriptor_ops.ipp
+index d700b22..1d0b73e 100644
+--- a/boost/asio/detail/impl/descriptor_ops.ipp
++++ b/boost/asio/detail/impl/descriptor_ops.ipp
+@@ -58,14 +58,9 @@ int close(int d, state_type& state, boost::system::error_code& ec)
+       // current OS where this behaviour is seen, Windows, says that the socket
+       // remains open. Therefore we'll put the descriptor back into blocking
+       // mode and have another attempt at closing it.
+-#if defined(__SYMBIAN32__)
+       int flags = ::fcntl(d, F_GETFL, 0);
+       if (flags >= 0)
+         ::fcntl(d, F_SETFL, flags & ~O_NONBLOCK);
+-#else // defined(__SYMBIAN32__)
+-      ioctl_arg_type arg = 0;
+-      ::ioctl(d, FIONBIO, &arg);
+-#endif // defined(__SYMBIAN32__)
+       state &= ~non_blocking;
+ 
+       errno = 0;
+@@ -88,7 +83,6 @@ bool set_user_non_blocking(int d, state_type& state,
+   }
+ 
+   errno = 0;
+-#if defined(__SYMBIAN32__)
+   int result = error_wrapper(::fcntl(d, F_GETFL, 0), ec);
+   if (result >= 0)
+   {
+@@ -96,10 +90,6 @@ bool set_user_non_blocking(int d, state_type& state,
+     int flag = (value ? (result | O_NONBLOCK) : (result & ~O_NONBLOCK));
+     result = error_wrapper(::fcntl(d, F_SETFL, flag), ec);
+   }
+-#else // defined(__SYMBIAN32__)
+-  ioctl_arg_type arg = (value ? 1 : 0);
+-  int result = error_wrapper(::ioctl(d, FIONBIO, &arg), ec);
+-#endif // defined(__SYMBIAN32__)
+ 
+   if (result >= 0)
+   {
+@@ -138,7 +128,6 @@ bool set_internal_non_blocking(int d, state_type& state,
+   }
+ 
+   errno = 0;
+-#if defined(__SYMBIAN32__)
+   int result = error_wrapper(::fcntl(d, F_GETFL, 0), ec);
+   if (result >= 0)
+   {
+@@ -146,10 +135,6 @@ bool set_internal_non_blocking(int d, state_type& state,
+     int flag = (value ? (result | O_NONBLOCK) : (result & ~O_NONBLOCK));
+     result = error_wrapper(::fcntl(d, F_SETFL, flag), ec);
+   }
+-#else // defined(__SYMBIAN32__)
+-  ioctl_arg_type arg = (value ? 1 : 0);
+-  int result = error_wrapper(::ioctl(d, FIONBIO, &arg), ec);
+-#endif // defined(__SYMBIAN32__)
+ 
+   if (result >= 0)
+   {
+diff --git a/boost/asio/detail/impl/socket_ops.ipp b/boost/asio/detail/impl/socket_ops.ipp
+index dc068e0..dcd0a55 100644
+--- a/boost/asio/detail/impl/socket_ops.ipp
++++ b/boost/asio/detail/impl/socket_ops.ipp
+@@ -333,14 +333,9 @@ int close(socket_type s, state_type& state,
+       ioctl_arg_type arg = 0;
+       ::ioctlsocket(s, FIONBIO, &arg);
+ #else // defined(BOOST_ASIO_WINDOWS) || defined(__CYGWIN__)
+-# if defined(__SYMBIAN32__)
+       int flags = ::fcntl(s, F_GETFL, 0);
+       if (flags >= 0)
+         ::fcntl(s, F_SETFL, flags & ~O_NONBLOCK);
+-# else // defined(__SYMBIAN32__)
+-      ioctl_arg_type arg = 0;
+-      ::ioctl(s, FIONBIO, &arg);
+-# endif // defined(__SYMBIAN32__)
+ #endif // defined(BOOST_ASIO_WINDOWS) || defined(__CYGWIN__)
+       state &= ~non_blocking;
+ 
+@@ -371,7 +366,7 @@ bool set_user_non_blocking(socket_type s,
+ #if defined(BOOST_ASIO_WINDOWS) || defined(__CYGWIN__)
+   ioctl_arg_type arg = (value ? 1 : 0);
+   int result = error_wrapper(::ioctlsocket(s, FIONBIO, &arg), ec);
+-#elif defined(__SYMBIAN32__)
++#else
+   int result = error_wrapper(::fcntl(s, F_GETFL, 0), ec);
+   if (result >= 0)
+   {
+@@ -379,9 +374,6 @@ bool set_user_non_blocking(socket_type s,
+     int flag = (value ? (result | O_NONBLOCK) : (result & ~O_NONBLOCK));
+     result = error_wrapper(::fcntl(s, F_SETFL, flag), ec);
+   }
+-#else
+-  ioctl_arg_type arg = (value ? 1 : 0);
+-  int result = error_wrapper(::ioctl(s, FIONBIO, &arg), ec);
+ #endif
+ 
+   if (result >= 0)
+@@ -424,7 +416,7 @@ bool set_internal_non_blocking(socket_type s,
+ #if defined(BOOST_ASIO_WINDOWS) || defined(__CYGWIN__)
+   ioctl_arg_type arg = (value ? 1 : 0);
+   int result = error_wrapper(::ioctlsocket(s, FIONBIO, &arg), ec);
+-#elif defined(__SYMBIAN32__)
++#else
+   int result = error_wrapper(::fcntl(s, F_GETFL, 0), ec);
+   if (result >= 0)
+   {
+@@ -432,9 +424,6 @@ bool set_internal_non_blocking(socket_type s,
+     int flag = (value ? (result | O_NONBLOCK) : (result & ~O_NONBLOCK));
+     result = error_wrapper(::fcntl(s, F_SETFL, flag), ec);
+   }
+-#else
+-  ioctl_arg_type arg = (value ? 1 : 0);
+-  int result = error_wrapper(::ioctl(s, FIONBIO, &arg), ec);
+ #endif
+ 
+   if (result >= 0)
+-- 
+2.0.1
+


### PR DESCRIPTION
The Cisco IOS XR networking stack doesn't accept `ioctl(fd, FIONBIO,
...)`, which is used by Boost.asio (and eventually pxp-agent). Patch
Boost to use `fnctl`'s `O_NONBLOCK` instead, which should be equivalent.