### PR TITLE
(maint) Make rust component compatible with latest vanagon

### DIFF
--- a/configs/components/rust.rb
+++ b/configs/components/rust.rb
@@ -1,10 +1,10 @@
 component 'rust' do |pkg, settings, platform|
   pkg.version '1.15.1'
-  if platform.is_osx?
+  if platform.is_macos?
     pkg.md5sum '5bb5b8bcf43cafe9e85fd7746a281ce1'
     pkg.url "https://static.rust-lang.org/dist/rust-#{pkg.get_version}-x86_64-apple-darwin.tar.gz"
   elsif platform.is_windows?
-    pkg.environment 'CYGWIN' => settings[:cygwin]
+    pkg.environment('CYGWIN', settings[:cygwin])
 
     if platform.architecture == 'x64'
       pkg.md5sum '8711e8d6672051296a186e9494444a30'
@@ -27,7 +27,7 @@ component 'rust' do |pkg, settings, platform|
     if platform.is_windows?
       # install.sh fails when doing a final check because of $(uname -s)
       [ "./install.sh --prefix=#{settings[:prefix]} --without=rust-docs || true",
-        "chmod -R 755 $$(cygpath -u #{settings[:prefix]})/lib"
+        "chmod -R 755 $(cygpath -u #{settings[:prefix]})/lib"
       ]
     else
       [ "./install.sh --prefix=#{settings[:prefix]} --without=rust-docs" ]

--- a/configs/components/rust.rb
+++ b/configs/components/rust.rb
@@ -1,24 +1,24 @@
 component 'rust' do |pkg, settings, platform|
-  pkg.version '1.15.1'
+  pkg.version '1.16.0'
   if platform.is_macos?
-    pkg.md5sum '5bb5b8bcf43cafe9e85fd7746a281ce1'
+    pkg.md5sum '747267e1c774419bac2215cf1db9ccfc'
     pkg.url "https://static.rust-lang.org/dist/rust-#{pkg.get_version}-x86_64-apple-darwin.tar.gz"
   elsif platform.is_windows?
     pkg.environment('CYGWIN', settings[:cygwin])
 
     if platform.architecture == 'x64'
-      pkg.md5sum '8711e8d6672051296a186e9494444a30'
+      pkg.md5sum '607c17d9622e2cb52a11a36686682a4b'
       pkg.url "https://static.rust-lang.org/dist/rust-#{pkg.get_version}-x86_64-pc-windows-gnu.tar.gz"
     else
-      pkg.md5sum '0aad70fd0bdd7f6d2061ca85cdce6bd6'
+      pkg.md5sum '7f7753a268407909346735f51d85cdba'
       pkg.url "https://static.rust-lang.org/dist/rust-#{pkg.get_version}-i686-pc-windows-gnu.tar.gz"
     end
   elsif platform.is_linux?
     if platform.architecture =~ /x86_64|amd64/
-      pkg.md5sum '0223554f067afc96413f0c0324608bbd'
+      pkg.md5sum '8b6f78dc023063c8790cf80df9b154bf'
       pkg.url "https://static.rust-lang.org/dist/rust-#{pkg.get_version}-x86_64-unknown-linux-gnu.tar.gz"
     elsif platform.architecture == 'i386'
-      pkg.md5sum '3a5df5c50ea1d8b47356f0336597d169'
+      pkg.md5sum '24cd47aafcaf358670ffe8b7700e25ec'
       pkg.url "https://static.rust-lang.org/dist/rust-#{pkg.get_version}-i686-unknown-linux-gnu.tar.gz"
     end
   end

--- a/configs/projects/pl-rust.rb
+++ b/configs/projects/pl-rust.rb
@@ -3,7 +3,7 @@ project "pl-rust" do |proj|
   instance_eval File.read('configs/projects/pl-build-tools.rb')
 
   proj.description "Puppet Labs Rust"
-  proj.version "1.15.1"
+  proj.version "1.16.0"
   proj.release "1"
   proj.license "Apache 2.0 and MIT"
   proj.vendor "Puppet Labs <info@puppetlabs.com>"


### PR DESCRIPTION
The latest vanagon don't like nil values in environment call value
parameters, this commit aligns the rust component with this expectation.