### PR TITLE
(BUILD-41) Support other platforms

### DIFF
--- a/configs/components/gettext.rb
+++ b/configs/components/gettext.rb
@@ -31,6 +31,34 @@ component "gettext" do |pkg, settings, platform|
     pkg.md5sum "97e034cf8ce5ba73a28ff6c3c0638092"
     pkg.url "http://ftp.gnu.org/gnu/#{pkg.get_name}/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
+    if platform.is_aix?
+      pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
+      pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/make-3.80-1.aix5.1.ppc.rpm"
+      pkg.environment("CC", "/opt/pl-build-tools/bin/gcc")
+    elsif platform.is_solaris?
+      if platform.os_version == '10'
+        pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-binutils-2.25.#{platform.architecture}.pkg.gz"
+        pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-gcc-4.8.2.#{platform.architecture}.pkg.gz"
+      elsif platform.os_version == '11'
+        pkg.build_requires "pl-gcc-#{platform.architecture}"
+        pkg.build_requires "pl-binutils-#{platform.architecture}"
+      end
+      pkg.build_requires "make"
+    else
+      pkg.build_requires "gcc"
+      pkg.build_requires "make"
+    end
+
+    if platform.is_solaris?
+      pkg.environment("PATH", "#{settings[:prefix]}/bin:#{settings[:basedir]}/bin:/usr/ccs/bin:/usr/sfw/bin:$(PATH)")
+    else
+      pkg.environment("PATH", "#{settings[:prefix]}/bin:$(PATH)")
+    end
+
+    if platform.name =~ /el-4/
+      pkg.build_requires "pl-tar"
+    end
+
     pkg.configure do
       ["./configure --prefix=#{settings[:prefix]} #{settings[:host]}"]
     end


### PR DESCRIPTION
Adds fixes for el-4, aix, and Solaris builds. These are essentially
copied from the autoconf component.