### PR TITLE
(BUILD-68) Fix gettext 0.19.8 build on EL5

### DIFF
--- a/configs/components/gettext.rb
+++ b/configs/components/gettext.rb
@@ -60,7 +60,7 @@ component "gettext" do |pkg, settings, platform|
     end
 
     pkg.configure do
-      ["./configure --prefix=#{settings[:prefix]} #{settings[:host]}"]
+      ["./configure --prefix=#{settings[:prefix]} #{settings[:host]} --without-emacs"]
     end
 
     pkg.build do


### PR DESCRIPTION
On EL5, there is a bug in the emacs scripts that gettext tries to
    install when it is built. These scripts are used to enable a special
    emacs mode for translators editing PO files. Since we don't need that
    here at all, this commit disables the emacs addons on all platforms.

I found this solution here: http://lists.busybox.net/pipermail/buildroot/2013-August/076126.html