### PR TITLE
(maint) Fix typo in s390x cmake toolchain file

### DIFF
--- a/files/cmake/rhel-sles-s390x-toolchain.cmake
+++ b/files/cmake/rhel-sles-s390x-toolchain.cmake
@@ -7,7 +7,7 @@ SET(CMAKE_SYSTEM_PROCESSOR s390x)
 # specify the cross compiler
 SET(PL_TOOLS_ROOT        /opt/pl-build-tools)
 SET(PL_TOOLS_PREFIX      ${PL_TOOLS_ROOT}/s390x-linux-gnu)
-SET(PL_TOOLS_SYSROOT     ${PL_TOOLS_PREFIX}/sysroot/lib/powerpc-linux-gnu)
+SET(PL_TOOLS_SYSROOT     ${PL_TOOLS_PREFIX}/sysroot/lib/s390x-linux-gnu)
 SET(CMAKE_C_COMPILER     ${PL_TOOLS_ROOT}/bin/s390x-linux-gnu-gcc)
 SET(CMAKE_CXX_COMPILER   ${PL_TOOLS_ROOT}/bin/s390x-linux-gnu-g++)
 SET(CMAKE_AR             ${PL_TOOLS_PREFIX}/bin/ar CACHE FILEPATH "Archiver")


### PR DESCRIPTION
Apparently there was some copypasta in here from the powerpc file. I'm pretty sure we're not even using this variable, but I figured I'd fix it. If we want to remove the variable definition completely, that can be a separate PR that would make the change to all the cmake toolchain files where relevant.