### PR TITLE
(maint) Use the latest code from packaging#master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ def vanagon_location_for(place)
 end
 
 gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || 'git@github.com:puppetlabs/vanagon#master')
-gem 'packaging', '~> 0.4.3', :github => 'puppetlabs/packaging', :branch => 'master'
+gem 'packaging', :github => 'puppetlabs/packaging', :branch => 'master'
 gem 'json'
 gem 'rake'


### PR DESCRIPTION
Letting this float to master, just as we do for vanagon. I discussed with RelEng and this was the preferred approach instead of pinning the gem to a higher revision.