### PR TITLE
(arch) Iinitial support for AArch64

### DIFF
--- a/configs/platforms/el-7-aarch64.rb
+++ b/configs/platforms/el-7-aarch64.rb
@@ -1,0 +1,11 @@
+platform "el-7-aarch64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+  
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/7/aarch64/pl-build-tools-aarch64.repo"
+  plat.provision_with "yum install -y autoconf automake rsync gcc make rpmdevtools rpm-libs"
+  plat.install_build_dependencies_with "yum install -y"
+  plat.vmpooler_template "centos-7-aarch64"
+end
+

--- a/configs/projects/pl-build-tools.rb
+++ b/configs/projects/pl-build-tools.rb
@@ -22,6 +22,8 @@ elsif platform.architecture == "armhf"
   platform_triple = "arm-linux-gnueabihf"
 elsif platform.architecture == "armel"
   platform_triple = "arm-linux-gnueabi"
+elsif platform.architecture == "aarch64"
+  platform_triple = "aarch64-linux-gnu"
 elsif platform.is_windows?
   if platform.architecture == "x64"
     platform_triple = "x86_64-unknown-mingw32"

--- a/configs/projects/pl-gcc.rb
+++ b/configs/projects/pl-gcc.rb
@@ -4,7 +4,7 @@ project "pl-gcc" do |proj|
 
   proj.description "Puppet Labs GCC"
 
-  if platform.name =~ /el-7-ppc64le|fedora-f24|fedora-f25|ubuntu-16\.04-ppc64el|ubuntu-16\.10|debian-8-armel/
+  if platform.name =~ /el-7-aarch64|el-7-ppc64le|fedora-f24|fedora-f25|ubuntu-16\.04-ppc64el|ubuntu-16\.10|debian-8-armel/
     proj.version "6.1.0"
     proj.release "5"
   elsif platform.is_aix? || platform.architecture == "s390x" || platform.architecture =~ /arm/

--- a/files/cmake/el-aarch64-toolchain.cmake
+++ b/files/cmake/el-aarch64-toolchain.cmake
@@ -1,0 +1,42 @@
+# this one is important
+SET(CMAKE_SYSTEM_NAME Linux)
+# these ones not so much
+SET(CMAKE_SYSTEM_VERSION 1)
+SET(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+# specify the cross compiler
+SET(PL_TOOLS_ROOT        /opt/pl-build-tools)
+SET(PL_TOOLS_PREFIX      ${PL_TOOLS_ROOT}/aarch64-linux-gnu)
+SET(PL_TOOLS_SYSROOT     ${PL_TOOLS_PREFIX}/sysroot/lib)
+SET(CMAKE_C_COMPILER     ${PL_TOOLS_ROOT}/bin/aarch64-linux-gnu-gcc)
+SET(CMAKE_CXX_COMPILER   ${PL_TOOLS_ROOT}/bin/aarch64-linux-gnu-g++)
+SET(CMAKE_AR             ${PL_TOOLS_PREFIX}/bin/ar CACHE FILEPATH "Archiver")
+SET(CMAKE_LINKER         ${PL_TOOLS_ROOT}/bin/aarch64-linux-gnu-gcc CACHE PATH "Linker Program")
+SET(CMAKE_NM             ${PL_TOOLS_PREFIX}/bin/nm)
+
+# where is the target environment
+SET(CMAKE_FIND_ROOT_PATH ${PL_TOOLS_PREFIX})
+
+# search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+# for libraries and headers in the target directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ALWAYS)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ALWAYS)
+
+SET(CMAKE_C_FLAGS "-fPIC -pthread ${CMAKE_C_FLAGS}" CACHE STRING "" FORCE)
+SET(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS}" CACHE STRING "" FORCE)
+
+# update RPATH so our custom libraries can be found
+# use, i.e. don't skip the full RPATH for the build tree
+SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+
+# when building, don't use the install RPATH already
+# (but later on when installing)
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
+# add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)


### PR DESCRIPTION
A first attempt at providing a vanogon build tools for CentOS7 on
AArch64 architecture. This patch assumes that the build will be
performed on AArch64 hardware. It also assumes (probably incorrectly)
that a vmpooler_template is available for aarch64.

I have been in contact with @ahpook from the puppet team and he
may be able to provide additional help in fixing this patch with
respect to puppetlabs internal build setup.

Signed-off-by: Richard Henwood <richard.henwood@arm.com>