### PR TITLE
Provide vanagon build tools from CentOS7 or RHELSA on AArch64

### DIFF
--- a/configs/components/gcc.rb
+++ b/configs/components/gcc.rb
@@ -1,6 +1,6 @@
 component "gcc" do |pkg, settings, platform|
   # Source-Related Metadata
-  if platform.name =~ /el-7-ppc64le|fedora-f24|fedora-f25|ubuntu-16\.04-ppc64el|ubuntu-16\.10/
+  if platform.name =~ /el-7-aarch64|el-7-ppc64le|fedora-f24|fedora-f25|ubuntu-16\.04-ppc64el|ubuntu-16\.10/
     pkg.version "6.1.0"
     pkg.md5sum "8d04cbdfddcfad775fdbc5e112af2690"
   elsif platform.is_aix? || platform.architecture == "s390x" || platform.architecture =~ /arm/
@@ -75,7 +75,7 @@ component "gcc" do |pkg, settings, platform|
       pkg.build_requires "g++"
       pkg.build_requires "libstdc++-dev"
       pkg.build_requires "libc6-dev"
-    when platform.architecture == "s390x" || platform.architecture == "ppc64le"
+    when platform.architecture == "s390x" || platform.architecture == "ppc64le" || platform.architecture == "aarch64"
       pkg.build_requires "pl-binutils-#{platform.architecture}"
       pkg.build_requires "sysroot"
       pkg.build_requires "libstdc++-devel"

--- a/configs/components/sysroot.rb
+++ b/configs/components/sysroot.rb
@@ -6,6 +6,9 @@ component "sysroot" do |pkg, settings, platform|
     when "debian-8-armel"
       pkg.version "2016.09.07"
       pkg.md5sum "d08a22cd4f431d4e1fc0d1869f60d9da"
+    when "el-7-aarch64"
+      pkg.version "2017.06.13"
+      pkg.md5sum "2767028fccf6176e199e88b365a2c75f"
     when "el-6-s390x"
       pkg.version "2016.05.23"
       pkg.md5sum "e08bc4f2a5cfb39033ee138fd22bd7f2"
@@ -50,7 +53,7 @@ component "sysroot" do |pkg, settings, platform|
   puts "sysroot base is " + sysroot_base
 
   libdirs = "lib"
-  libdirs = "lib lib64" if platform.architecture == "s390x" || platform.name =~ /el-7-ppc64le/
+  libdirs = "lib lib64" if platform.architecture == "s390x" || platform.name =~ /el-7-ppc64le/ || platform.architecture == "aarch64"
   pkg.install do
     [
       "mv #{libdirs} #{sysroot_base}/",

--- a/configs/components/toolchain.rb
+++ b/configs/components/toolchain.rb
@@ -8,10 +8,11 @@ component "toolchain" do |pkg, settings, platform|
       pkg.add_source "file://files/cmake/debian-8-armhf-toolchain.cmake"
       pkg.add_source "file://files/cmake/debian-8-armel-toolchain.cmake"
     elsif platform.name =~ /el-\d-x86_64|sles-\d\d-x86_64/
-      # Toolchain files for rhel and sles running on IBM z-series and
-      # Power8, which builds on x86_64
+      # Toolchain files for rhel and sles running on IBM z-series, Power8, 
+      # and aarch64, which builds on x86_64
       pkg.add_source "file://files/cmake/el-ppc64le-toolchain.cmake"
       pkg.add_source "file://files/cmake/rhel-sles-s390x-toolchain.cmake"
+      pkg.add_source "file://files/cmake/rhel-sles-aarch64-toolchain.cmake"
     elsif platform.name =~ /ubuntu-16\.04-amd64/
       # Toolchain file for Ubuntu 16.04 running on IBM Power8 hardware,
       # which builds on amd64
@@ -70,9 +71,10 @@ component "toolchain" do |pkg, settings, platform|
       pkg.install_file "debian-8-armhf-toolchain.cmake", "#{settings[:basedir]}/arm-linux-gnueabihf/pl-build-toolchain.cmake"
       pkg.install_file "debian-8-armel-toolchain.cmake", "#{settings[:basedir]}/arm-linux-gnueabi/pl-build-toolchain.cmake"
     elsif platform.name =~ /el-\d-x86_64|sles-\d\d-x86_64/
-      # Install toolchain files used by the s390x/Power8 rhel and sles platfoms, which are built on x86_64
+      # Install toolchain files used by the s390x/Power8/aarch64 rhel and sles platfoms, which are built on x86_64
       pkg.install_file "rhel-sles-s390x-toolchain.cmake", "#{settings[:basedir]}/s390x-linux-gnu/pl-build-toolchain.cmake"
       pkg.install_file "el-ppc64le-toolchain.cmake", "#{settings[:basedir]}/ppc64le-redhat-linux/pl-build-toolchain.cmake"
+      pkg.install_file "el-aarch64-toolchain.cmake", "#{settings[:basedir]}/aarch64-redhat-linux/pl-build-toolchain.cmake"
 	elsif platform.name =~ /ubuntu-16\.04-amd64/
       # Install toolchain file used by the Power8 ubuntu platfom, which is built on amd64
       pkg.install_file "ubuntu-powerpc64le-toolchain.cmake", "#{settings[:basedir]}/powerpc64le-linux-gnu/pl-build-toolchain.cmake"

--- a/configs/platforms/el-7-aarch64.rb
+++ b/configs/platforms/el-7-aarch64.rb
@@ -1,0 +1,12 @@
+platform "el-7-aarch64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/7/aarch64/pl-build-tools-aarch64.repo"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/7/x86_64/pl-build-tools-x86_64.repo"
+  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.install_build_dependencies_with "yum install --assumeyes"
+  plat.cross_compiled true
+  plat.vmpooler_template "redhat-7-x86_64"
+end

--- a/configs/projects/pl-build-tools.rb
+++ b/configs/projects/pl-build-tools.rb
@@ -18,6 +18,8 @@ elsif platform.architecture == "ppc64el" && platform.is_deb?
   platform_triple = "powerpc64le-linux-gnu"
 elsif platform.architecture == "ppc64le" && platform.is_rpm?
   platform_triple = "ppc64le-redhat-linux"
+elsif platform.architecture == "aarch64" && platform.is_rpm?
+  platform_triple = "aarch64-redhat-linux"
 elsif platform.architecture == "armhf"
   platform_triple = "arm-linux-gnueabihf"
 elsif platform.architecture == "armel"

--- a/configs/projects/pl-cmake.rb
+++ b/configs/projects/pl-cmake.rb
@@ -8,7 +8,7 @@ project "pl-cmake" do |proj|
     proj.release "5"
   else
     proj.version "3.2.3"
-    proj.release "17"
+    proj.release "18"
   end
   proj.license "BSD"
   proj.vendor "Puppet Labs <info@puppetlabs.com>"

--- a/configs/projects/pl-gcc.rb
+++ b/configs/projects/pl-gcc.rb
@@ -4,7 +4,7 @@ project "pl-gcc" do |proj|
 
   proj.description "Puppet Labs GCC"
 
-  if platform.name =~ /el-7-ppc64le|fedora-f24|fedora-f25|ubuntu-16\.04-ppc64el|ubuntu-16\.10|debian-8-armel/
+  if platform.name =~ /el-7-aarch64|el-7-ppc64le|fedora-f24|fedora-f25|ubuntu-16\.04-ppc64el|ubuntu-16\.10|debian-8-armel/
     proj.version "6.1.0"
     proj.release "5"
   elsif platform.is_aix? || platform.architecture == "s390x" || platform.architecture =~ /arm/

--- a/files/cmake/el-aarch64-toolchain.cmake
+++ b/files/cmake/el-aarch64-toolchain.cmake
@@ -1,0 +1,42 @@
+# this one is important
+SET(CMAKE_SYSTEM_NAME Linux)
+# these ones not so much
+SET(CMAKE_SYSTEM_VERSION 1)
+SET(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+# specify the cross compiler
+SET(PL_TOOLS_ROOT        /opt/pl-build-tools)
+SET(PL_TOOLS_PREFIX      ${PL_TOOLS_ROOT}/aarch64-redhat-linux)
+SET(PL_TOOLS_SYSROOT     ${PL_TOOLS_PREFIX}/sysroot/lib)
+SET(CMAKE_C_COMPILER     ${PL_TOOLS_ROOT}/bin/aarch64-redhat-linux-gcc)
+SET(CMAKE_CXX_COMPILER   ${PL_TOOLS_ROOT}/bin/aarch64-redhat-linux-g++)
+SET(CMAKE_AR             ${PL_TOOLS_PREFIX}/bin/ar CACHE FILEPATH "Archiver")
+SET(CMAKE_LINKER         ${PL_TOOLS_ROOT}/bin/aarch64-redhat-linux-gcc CACHE PATH "Linker Program")
+SET(CMAKE_NM             ${PL_TOOLS_PREFIX}/bin/nm)
+
+# where is the target environment
+SET(CMAKE_FIND_ROOT_PATH ${PL_TOOLS_PREFIX})
+
+# search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+# for libraries and headers in the target directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ALWAYS)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ALWAYS)
+
+SET(CMAKE_C_FLAGS "-fPIC -pthread ${CMAKE_C_FLAGS}" CACHE STRING "" FORCE)
+SET(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS}" CACHE STRING "" FORCE)
+
+# update RPATH so our custom libraries can be found
+# use, i.e. don't skip the full RPATH for the build tree
+SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+
+# when building, don't use the install RPATH already
+# (but later on when installing)
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
+# add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)

--- a/scripts/generate_el-7-aarch64_sysroot.sh
+++ b/scripts/generate_el-7-aarch64_sysroot.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+#
+# This script generates a sysroot tarball for the el-7-aarch64 (aka
+# arm64) platform. For our builds we cross-compile most of our packages
+# on a redhat-7-x86_64 pooler system, but the sysroot must be created
+# from a native AArch64 environment. Therefore, you must run this script
+# as root on a AArch64 server running CentOS or RHELSA 7.
+
+sysrootdir="el-7-aarch64-sysroot"
+
+# First we remove a bunch of unneeded junk. The purpose of this is to try
+# to get rid of unneeded library files and minmize the size of the sysroot,
+# even though we'll still be pruning the libdirs in a later step.
+#
+# Note: we cannot remove libxml2-python, as it is in the dependency chain for
+# subscription-manager, which we need to keep the yum repos enabled for this
+# platform. 
+echo "Removing unneeded packages..."
+yum remove -y autofs cups-libs git-core libtiff libxslt mysql-libs opencryptoki-libs pango plymouth-core-libs python-lxml sssd-client samba-common systemtap-runtime
+
+echo "Installing critical libraries we need for building gcc and our various dependencies..."
+yum install --assumeyes rsync zlib-devel bzip2-devel libblkid-devel libcurl-devel libselinux-devel readline-devel e2fsprogs-devel xz-devel
+
+# Create a sysroot working area we can make further modifications to
+echo "Creating $sysrootdir and syncing sysroot directories under it..."
+rm -rf $sysrootdir
+mkdir -p $sysrootdir/usr
+rsync --archive /usr/lib64 $sysrootdir/usr/
+rsync --archive --copy-dirlinks /usr/include $sysrootdir/usr/
+
+echo "Pruning sysroot libdirs of unneeded files and directories..."
+# I always try to delete libnss* and libkrb*, but they're actually needed by libcurl, so don't do that:
+rm -r $sysrootdir/usr/lib64/{a,cracklib,d,e,f,g,k,libasound,libau,libavahi,libdev,libgio,libgnutls,liblvm,libmoz,libpython,librpm,libslang,libsoup,libsystemd,libX,libxcb,libxml,lua,m,NetworkManager,n,o,p,r,s,t,X11,x}*
+
+# Since we're relocating the sysroot, we can't have absolute symlinks
+echo "Converting absolute library symlinks to relative ones..."
+pushd $sysrootdir/usr/lib64
+find . -maxdepth 1 -lname '/*' |
+while read -r link ; do
+  echo "Converting $link from absolute to relative..."
+  target=$(readlink "$link")
+  # shellcheck disable=SC2001
+  reltarget=$(echo "$target" | sed 's|/lib64|../../lib64|g')
+  rm "$link"
+  ln -sf "$reltarget" "$link"
+done
+popd
+
+# On RHEL 7, /lib64 is a symlink to /usr/lib64. But we need to avoid
+# including any symlinks to directories to avoid packaging errors. So
+# convert any symlinks from ../../lib64/ to point to their targets, which are
+# in the current directory anyway.
+echo "Converting problematic library symlinks to local ones..."
+pushd $sysrootdir/usr/lib64
+find . -maxdepth 1 -lname '../../lib64/*' |
+while read -r link ; do
+  echo "Converting $link..."
+  target=$(readlink "$link")
+  # shellcheck disable=SC2001
+  reltarget=$(echo "$target" | sed 's|../../lib64/||g')
+  rm "$link"
+  ln -sf "$reltarget" "./$link"
+done
+popd
+
+# AArch64 is a 64-bit platform and keeps those libs in /lib64 and /usr/lib64.
+# But when building gcc, you'll run into errors finding libraries if you
+# use "lib64" in the sysroot, but also when using a sysroot that stored the
+# libraries in "lib" instead. A workaround to this is to just have both
+# directories.
+echo "Duplicating libdirs so both 'lib' and 'lib64' are available during compiles..."
+cp -a $sysrootdir/usr/lib64 $sysrootdir/lib64
+cp -a $sysrootdir/lib64 $sysrootdir/lib
+cp -a $sysrootdir/usr/lib64 $sysrootdir/usr/lib
+
+echo "Generating the sysroot tarball..."
+if [ -e $sysrootdir.tar.gz ]; then
+  rm $sysrootdir.tar.gz
+fi
+tar --create --gzip --file $sysrootdir.tar.gz --owner=0 --group=0 $sysrootdir
+
+echo "Done. Now copy $sysrootdir.tar.gz over to buildsources."


### PR DESCRIPTION
This patch assumes that the tools will be cross compiled on x86.
It uses machine triple 'aarch64-redhat-linux' as discussed on
https://github.com/puppetlabs/pl-build-tools-vanagon/pull/26

Signed-off-by: Richard Henwood richard.henwood@arm.com