### PR TITLE
Debian 9 (Stretch) Platform Additions

### DIFF
--- a/configs/components/gcc.rb
+++ b/configs/components/gcc.rb
@@ -1,6 +1,6 @@
 component "gcc" do |pkg, settings, platform|
   # Source-Related Metadata
-  if platform.name =~ /el-7-aarch64|el-7-ppc64le|fedora-f24|fedora-f25|ubuntu-16\.04-ppc64el|ubuntu-16\.10/
+  if platform.name =~ /debian-9|el-7-aarch64|el-7-ppc64le|fedora-f24|fedora-f25|ubuntu-16\.04-ppc64el|ubuntu-16\.10/
     pkg.version "6.1.0"
     pkg.md5sum "8d04cbdfddcfad775fdbc5e112af2690"
   elsif platform.is_aix? || platform.architecture == "s390x" || platform.architecture =~ /arm/

--- a/configs/platforms/debian-9-amd64.rb
+++ b/configs/platforms/debian-9-amd64.rb
@@ -1,0 +1,12 @@
+platform "debian-9-amd64" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "stretch"
+
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vmpooler_template "debian-9-x86_64"
+  plat.output_dir File.join("deb", plat.get_codename)
+end

--- a/configs/platforms/debian-9-i386.rb
+++ b/configs/platforms/debian-9-i386.rb
@@ -1,0 +1,11 @@
+platform "debian-9-i386" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "stretch"
+
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vmpooler_template "debian-9-i386"
+end

--- a/configs/projects/pl-gcc.rb
+++ b/configs/projects/pl-gcc.rb
@@ -4,7 +4,7 @@ project "pl-gcc" do |proj|
 
   proj.description "Puppet Labs GCC"
 
-  if platform.name =~ /el-7-aarch64|el-7-ppc64le|fedora-f24|fedora-f25|ubuntu-16\.04-ppc64el|ubuntu-16\.10|debian-8-armel/
+  if platform.name =~ /debian-8-armel|debian-9|el-7-aarch64|el-7-ppc64le|fedora-f24|fedora-f25|ubuntu-16\.04-ppc64el|ubuntu-16\.10/
     proj.version "6.1.0"
     proj.release "5"
   elsif platform.is_aix? || platform.architecture == "s390x" || platform.architecture =~ /arm/


### PR DESCRIPTION
This is the set of changes needed to build our pl-build-tools packages for Debian 9 (Stretch) for x86 and x86_64 architectures. 

I've used the packages generated from these changes to successfully build working Debian 9 agents, so this code is tested and is known to work.