### PR TITLE
Fix Solaris 11 Builds

### DIFF
--- a/configs/projects/pl-binutils.rb
+++ b/configs/projects/pl-binutils.rb
@@ -2,7 +2,7 @@ project "pl-binutils" do |proj|
   # Project level settings our components will care about
   instance_eval File.read('configs/projects/pl-build-tools.rb')
 
-  if platform.is_cross_compiled_linux?
+  if platform.is_cross_compiled?
     proj.name "pl-binutils-#{platform.architecture}"
     # We need to set noarch here - otherwise the generated packages
     # will specify the target arch and not be installable

--- a/configs/projects/pl-boost.rb
+++ b/configs/projects/pl-boost.rb
@@ -14,7 +14,7 @@ project "pl-boost" do |proj|
   proj.vendor "Puppet Labs <info@puppetlabs.com>"
   proj.homepage "https://www.puppetlabs.com"
 
-  if platform.is_cross_compiled?
+  if platform.is_cross_compiled? || platform.name =~ /solaris-11/
     proj.name "pl-boost-#{platform.architecture}"
     proj.noarch
   else

--- a/configs/projects/pl-boost.rb
+++ b/configs/projects/pl-boost.rb
@@ -14,7 +14,7 @@ project "pl-boost" do |proj|
   proj.vendor "Puppet Labs <info@puppetlabs.com>"
   proj.homepage "https://www.puppetlabs.com"
 
-  if platform.is_cross_compiled_linux?
+  if platform.is_cross_compiled?
     proj.name "pl-boost-#{platform.architecture}"
     proj.noarch
   else

--- a/configs/projects/pl-gcc.rb
+++ b/configs/projects/pl-gcc.rb
@@ -15,7 +15,7 @@ project "pl-gcc" do |proj|
     proj.release "9"
   end
 
-  if platform.is_cross_compiled_linux?
+  if platform.is_cross_compiled?
     proj.name "pl-gcc-#{platform.architecture}"
     proj.noarch
   end

--- a/configs/projects/pl-yaml-cpp.rb
+++ b/configs/projects/pl-yaml-cpp.rb
@@ -14,7 +14,7 @@ project "pl-yaml-cpp" do |proj|
   proj.vendor "Puppet Labs <info@puppetlabs.com>"
   proj.homepage "https://www.puppetlabs.com"
 
-  if platform.is_cross_compiled_linux?
+  if platform.is_cross_compiled?
     proj.name "pl-yaml-cpp-#{platform.architecture}"
     proj.noarch
   else


### PR DESCRIPTION
A while back I had mistakenly excluded solaris builds from the cross_compiled check which includes the platform architecture in the package name. This reverts that commit and fixes errors when building the pl-boost package for solaris-11-i386.  