### PR TITLE
(PA-1487) Update fedora-14 build to not provision system gcc

### DIFF
--- a/configs/platforms/fedora-f14-i386.rb
+++ b/configs/platforms/fedora-f14-i386.rb
@@ -2,7 +2,7 @@
 platform "fedora-f14-i386" do |plat|
   plat.servicetype "sysv"
 
-  plat.provision_with "yum install -y --nogpgcheck autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils"
+  plat.provision_with "yum install -y --nogpgcheck autoconf automake createrepo rsync glibc-devel make rpm-build rpm-libs yum-utils"
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/fedora/14/i386/pl-build-tools-fedora-14.repo"
   plat.install_build_dependencies_with "yum install -y --nogpgcheck"
   plat.vmpooler_template "fedora-14-i386"


### PR DESCRIPTION
When system gcc is provisioned, builds of pl-gettext will link against the
system gcc and cause issues when builds atttempt to only use pl-gcc