### PR TITLE
Changes to get el-7-aarch64 builds working

### DIFF
--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -23,6 +23,10 @@ component "boost" do |pkg, settings, platform|
     pkg.apply_patch 'resources/patches/boost/no-fionbio.patch'
   end
 
+  if platform.architecture == "aarch64"
+    pkg.apply_patch 'resources/patches/boost/boost-aarch64-flags.patch'
+  end
+
   # Package Dependency Metadata
 
   # Build Requirements

--- a/configs/components/sysroot.rb
+++ b/configs/components/sysroot.rb
@@ -8,7 +8,7 @@ component "sysroot" do |pkg, settings, platform|
       pkg.md5sum "d08a22cd4f431d4e1fc0d1869f60d9da"
     when "el-7-aarch64"
       pkg.version "2017.06.13"
-      pkg.md5sum "2767028fccf6176e199e88b365a2c75f"
+      pkg.md5sum "b1cb6fc6253a2bbb5cc17fda16ec64ae"
     when "el-6-s390x"
       pkg.version "2016.05.23"
       pkg.md5sum "e08bc4f2a5cfb39033ee138fd22bd7f2"

--- a/resources/patches/boost/boost-aarch64-flags.patch
+++ b/resources/patches/boost/boost-aarch64-flags.patch
@@ -1,0 +1,17 @@
+# Boost doesn't build with the -m64 option on aarch64, and the compiler
+# builds 64-bit binaries by default, so remove the option.
+Index: boost_1_58_0/tools/build/src/tools/gcc.jam
+===================================================================
+--- boost_1_58_0.orig/tools/build/src/tools/gcc.jam
++++ boost_1_58_0/tools/build/src/tools/gcc.jam
+@@ -457,10 +457,6 @@ rule setup-address-model ( targets * : s
+                 {
+                     option = -m32 ;
+                 }
+-                else if $(model) = 64
+-                {
+-                    option = -m64 ;
+-                }
+             }
+             # For darwin, the model can be 32_64. darwin.jam will handle that
+             # on its own.


### PR DESCRIPTION
This builds on previous work from a community contributor who got aarch64 builds working. This just updates the md5sum of the sysroot tarball (which we had to generate ourselves), and fixes a compiler flag compatibility issue in pl-boost.

All of the pl-build-tools packages from this branch have been built and used successfully to build an el-7-aarch64 agent. 