### PR TITLE
(BUILD-149) (BUILD-150) Add Ubuntu 18.04 configs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ def location_for(place)
 end
 
 gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.15')
-gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')
+gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~>1.0')
 gem 'json'
 gem 'rake'

--- a/configs/components/gcc.rb
+++ b/configs/components/gcc.rb
@@ -1,6 +1,6 @@
 component "gcc" do |pkg, settings, platform|
   # Source-Related Metadata
-  if platform.name =~ /debian-9|el-7-aarch64|el-7-ppc64le|fedora-f24|fedora-f25|fedora-f26|fedora-f27|sles-12-ppc64le|ubuntu-16\.04-ppc64el|ubuntu-16\.10/
+  if platform.name =~ /debian-9|el-7-aarch64|el-7-ppc64le|fedora-f24|fedora-f25|fedora-f26|fedora-f27|sles-12-ppc64le|ubuntu-16\.04-ppc64el|ubuntu-16\.10|ubuntu-18\.04/
     pkg.version "6.1.0"
     pkg.md5sum "8d04cbdfddcfad775fdbc5e112af2690"
   elsif platform.is_aix? || platform.architecture == "s390x" || platform.architecture =~ /arm/
@@ -14,17 +14,15 @@ component "gcc" do |pkg, settings, platform|
 
   pkg.apply_patch "resources/patches/gcc/aix-inclhack.patch" if platform.is_aix?
 
-  # These patches are necessary because Fedora 27 uses glib 2.26 instead of glib 2.25;
-  # the latter is what Fedora 26 used. glib 2.26 results in the following errors when
-  # building gcc:
+  # glib 2.26 produces the following errors when building with gcc 5.y or 6.y:
   #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81712
   #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81066
   #
-  # Any (future) Linux platforms that use glib 2.26 with gcc 5.y or 6.y should have these
+  # Any Linux platforms that use glib 2.26+ with gcc 5.y or 6.y should have these
   # patches applied.
   #
-  # On Fedora, you can check the glib version by running `ldd --version`
-  if platform.name =~ /fedora-f27/
+  # On Linux, you can check the glib version by running `ldd --version`
+  if platform.name =~ /fedora-f27/ || platform.name =~ /ubuntu-18.04/
     pkg.apply_patch "resources/patches/gcc/ucontext_t-linux-unwind_h.patch"
     pkg.apply_patch "resources/patches/gcc/sanitizer_linux.patch"
   end

--- a/configs/platforms/ubuntu-18.04-amd64.rb
+++ b/configs/platforms/ubuntu-18.04-amd64.rb
@@ -1,0 +1,12 @@
+platform "ubuntu-18.08-amd64" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "bionic"
+
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vmpooler_template "ubuntu-1804-x86_64"
+  plat.output_dir File.join("deb", plat.get_codename)
+end


### PR DESCRIPTION
I was able to build the following with these commits:
- pl-gcc (6.1.0)
- pl-boost (1.58)
- pl-cmake (3.2.3)
- pl-yaml-cpp (0.5.1)
- pl-gettext (0.19.8.1)

Also includes an update to the default version of the packaging gem; Let me know if that won't work out for some reason - we can still use `PACKAGING_LOCATION` instead if needed.