### PR TITLE
(BUILD-150) Correct pl-gcc version name for 18.04

### DIFF
--- a/configs/projects/pl-gcc.rb
+++ b/configs/projects/pl-gcc.rb
@@ -4,9 +4,9 @@ project "pl-gcc" do |proj|
 
   proj.description "Puppet Labs GCC"
 
-  if platform.name =~ /debian-8-armel|debian-9|el-7-aarch64|el-7-ppc64le|fedora-f24|fedora-f25|fedora-f26|fedora-f27|sles-12-ppc64le|ubuntu-16\.04-ppc64el|ubuntu-16\.10/
+  if platform.name =~ /debian-8-armel|debian-9|el-7-aarch64|el-7-ppc64le|fedora-f24|fedora-f25|fedora-f26|fedora-f27|sles-12-ppc64le|ubuntu-16\.04-ppc64el|ubuntu-16\.10|ubuntu-18\.04/
     proj.version "6.1.0"
-    proj.release "5"
+    proj.release "6"
   elsif platform.is_aix? || platform.architecture == "s390x" || platform.architecture =~ /arm/
     proj.version "5.2.0"
     proj.release "11"


### PR DESCRIPTION
Updates the revision of pl-gcc and corrects the gcc version used in
package names for Ubuntu 18.04