### PR TITLE
(BUILD-141) Add support for Fedora 28

### DIFF
--- a/configs/components/gcc.rb
+++ b/configs/components/gcc.rb
@@ -1,6 +1,6 @@
 component "gcc" do |pkg, settings, platform|
   # Source-Related Metadata
-  if platform.name =~ /debian-9|el-7-aarch64|el-7-ppc64le|fedora-f24|fedora-f25|fedora-f26|fedora-f27|sles-12-ppc64le|ubuntu-16\.04-ppc64el|ubuntu-16\.10|ubuntu-18\.04/
+  if platform.name =~ /debian-9|el-7-aarch64|el-7-ppc64le|fedora-f24|fedora-f25|fedora-f26|fedora-f27|fedora-28|sles-12-ppc64le|ubuntu-16\.04-ppc64el|ubuntu-16\.10|ubuntu-18\.04/
     pkg.version "6.1.0"
     pkg.md5sum "8d04cbdfddcfad775fdbc5e112af2690"
   elsif platform.is_aix? || platform.architecture == "s390x" || platform.architecture =~ /arm/
@@ -22,7 +22,7 @@ component "gcc" do |pkg, settings, platform|
   # patches applied.
   #
   # On Linux, you can check the glib version by running `ldd --version`
-  if platform.name =~ /fedora-f27/ || platform.name =~ /ubuntu-18.04/
+  if platform.name =~ /fedora-f27|fedora-28|ubuntu-18.04/
     pkg.apply_patch "resources/patches/gcc/ucontext_t-linux-unwind_h.patch"
     pkg.apply_patch "resources/patches/gcc/sanitizer_linux.patch"
   end

--- a/configs/platforms/fedora-28-x86_64.rb
+++ b/configs/platforms/fedora-28-x86_64.rb
@@ -1,0 +1,11 @@
+platform "fedora-28-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+  plat.dist "fc28"
+
+  plat.provision_with "dnf install -y --best --allowerasing autoconf automake rsync gcc make rpmdevtools rpm-libs"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-28.noarch.rpm"
+  plat.install_build_dependencies_with "dnf install -y --best --allowerasing"
+  plat.vmpooler_template "fedora-28-x86_64"
+end

--- a/configs/projects/pl-gcc.rb
+++ b/configs/projects/pl-gcc.rb
@@ -4,7 +4,7 @@ project "pl-gcc" do |proj|
 
   proj.description "Puppet Labs GCC"
 
-  if platform.name =~ /debian-8-armel|debian-9|el-7-aarch64|el-7-ppc64le|fedora-f24|fedora-f25|fedora-f26|fedora-f27|sles-12-ppc64le|ubuntu-16\.04-ppc64el|ubuntu-16\.10|ubuntu-18\.04/
+  if platform.name =~ /debian-8-armel|debian-9|el-7-aarch64|el-7-ppc64le|fedora-f24|fedora-f25|fedora-f26|fedora-f27|fedora-28|sles-12-ppc64le|ubuntu-16\.04-ppc64el|ubuntu-16\.10|ubuntu-18\.04/
     proj.version "6.1.0"
     proj.release "6"
   elsif platform.is_aix? || platform.architecture == "s390x" || platform.architecture =~ /arm/


### PR DESCRIPTION
This is the first Fedora release where we no longer have to include the
'f' in the version field due to improvements in our packaging gem.