### PR TITLE
(maint) Be more specific with packaging dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ def location_for(place)
 end
 
 gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.15')
-gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~>1.0')
+gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99.4')
 gem 'json'
 gem 'rake'


### PR DESCRIPTION
This commit adds a Z version to the packaging gem dependency. Previously, older
versions could get pulled in, which don't have necessary updates, like new
platforms, which causes shipping to fail.