### PR TITLE
(PA-2107) Add a pl-perl project

### DIFF
--- a/configs/components/perl.rb
+++ b/configs/components/perl.rb
@@ -1,0 +1,18 @@
+component "perl" do |pkg, settings, platform|
+  pkg.version "5.26.2"
+  pkg.md5sum "dc0fea097f3992a8cd53f8ac0810d523"
+  pkg.url "https://www.cpan.org/src/5.0/perl-#{pkg.get_version}.tar.gz"
+  pkg.mirror "https://artifactory.delivery.puppetlabs.net/artifactory/generic__buildsources/buildsources/perl-#{pkg.get_version}.tar.gz"
+
+  pkg.configure do
+    [ "sh Configure -de -Dprefix=#{settings[:prefix]}" ]
+  end
+
+  pkg.build do
+    [ platform[:make] ]
+  end
+
+  pkg.install do
+    [ "#{platform[:make]} install" ]
+  end
+end

--- a/configs/projects/pl-perl.rb
+++ b/configs/projects/pl-perl.rb
@@ -1,0 +1,16 @@
+project "pl-perl" do |proj|
+  # Project level settings our components will care about
+  instance_eval File.read('configs/projects/pl-build-tools.rb')
+
+  proj.description "Puppet perl"
+  proj.version "5.26.2"
+  proj.license "See components"
+  proj.vendor "Puppet Labs <info@puppetlabs.com>"
+  proj.homepage "https://www.puppetlabs.com"
+
+  proj.setting(:cflags, "-I#{proj.includedir}")
+  proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir}")
+
+  proj.component "perl"
+  proj.target_repo ""
+end


### PR DESCRIPTION
[Here's an example build of this package](https://jenkins-master-prod-1.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1/) -- The Windows, AIX, and Solaris 10 builds, plus a few one-off others (ubuntu 16.04 power, for example) don't work, but this project is intended for use specifically with EL 5. I've tested a build of puppet-runtime with a pl-perl package produced by these changes and it seems to configure and build openssl 1.1.0 successfully.