### PR TITLE
(PA-2158) Adding support for el-7-ppc64 - Cleaned Commit History

### DIFF
--- a/configs/components/autoconf.rb
+++ b/configs/components/autoconf.rb
@@ -2,6 +2,7 @@ component "autoconf" do |pkg, settings, platform|
   pkg.version "2.69"
   pkg.md5sum "82d05e03b93e45f5a39b828dc9c6c29b"
   pkg.url "http://ftp.gnu.org/gnu/autoconf/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"

--- a/configs/components/automake.rb
+++ b/configs/components/automake.rb
@@ -2,6 +2,7 @@ component "automake" do |pkg, settings, platform|
   pkg.version "1.15"
   pkg.md5sum "716946a105ca228ab545fc37a70df3a3"
   pkg.url "http://ftp.gnu.org/gnu/automake/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"

--- a/configs/components/binutils.rb
+++ b/configs/components/binutils.rb
@@ -5,16 +5,17 @@ component "binutils" do |pkg, settings, platform|
     # https://sourceware.org/bugzilla/show_bug.cgi?id=19520
     pkg.version "2.27"
     pkg.md5sum "41b053ed4fb2c6a8173ef421460fbb28"
-    pkg.url "https://ftp.gnu.org/gnu/binutils/binutils-#{pkg.get_version}.tar.gz"
   else
     pkg.version "2.26"
     pkg.md5sum "d66e2b663757cbf5d4b060feb4ef6b4b"
-    pkg.url "https://ftp.gnu.org/gnu/binutils/binutils-#{pkg.get_version}.tar.gz"
 
     pkg.apply_patch "resources/patches/binutils/binutils-2.23.2-common.h.patch"
     pkg.apply_patch "resources/patches/binutils/binutils-2.23.2-ldlang.c.patch"
     pkg.apply_patch "resources/patches/binutils/binutils-2.26-tci386-BFD.patch"
   end
+
+  pkg.url "https://ftp.gnu.org/gnu/binutils/binutils-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/binutils-#{pkg.get_version}.tar.gz"
 
   # Package Dependency Metadata
 

--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -10,6 +10,7 @@ component "boost" do |pkg, settings, platform|
 
   # Apparently boost doesn't use dots to version they use underscores....arg
   pkg.url "http://downloads.sourceforge.net/project/boost/boost/#{pkg.get_version}/boost_#{pkg.get_version.gsub('.','_')}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/boost_#{pkg.get_version.gsub('.','_')}.tar.gz"
 
   if platform.is_solaris?
     pkg.apply_patch 'resources/patches/boost/solaris-10-boost-build.patch'

--- a/configs/components/cmake.rb
+++ b/configs/components/cmake.rb
@@ -10,6 +10,8 @@ component "cmake" do |pkg, settings, platform|
     pkg.url "https://cmake.org/files/v3.2/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
   end
 
+  pkg.mirror "#{settings[:buildsources_url]}/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+
   if platform.name =~ /sles-12/
     pkg.apply_patch 'resources/patches/cmake/avoid-select-sles-12.patch'
   elsif platform.is_solaris?

--- a/configs/components/cmake.rb
+++ b/configs/components/cmake.rb
@@ -1,12 +1,14 @@
 component "cmake" do |pkg, settings, platform|
   # Source-Related Metadata
-  pkg.version "3.2.3"
-  pkg.md5sum "d51c92bf66b1e9d4fe2b7aaedd51377c"
   if platform.name =~ /fedora-f24/
     pkg.version "3.5.2"
     pkg.md5sum "701386a1b5ec95f8d1075ecf96383e02"
+    pkg.url "https://cmake.org/files/v3.5/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  else
+    pkg.version "3.2.3"
+    pkg.md5sum "d51c92bf66b1e9d4fe2b7aaedd51377c"
+    pkg.url "https://cmake.org/files/v3.2/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
   end
-  pkg.url "#{settings[:buildsources_url]}/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   if platform.name =~ /sles-12/
     pkg.apply_patch 'resources/patches/cmake/avoid-select-sles-12.patch'

--- a/configs/components/gcc.rb
+++ b/configs/components/gcc.rb
@@ -11,6 +11,7 @@ component "gcc" do |pkg, settings, platform|
     pkg.md5sum "deca88241c1135e2ff9fa5486ab5957b"
   end
   pkg.url "http://ftp.gnu.org/gnu/gcc/gcc-#{pkg.get_version}/gcc-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/gcc-#{pkg.get_version}.tar.gz"
 
   pkg.apply_patch "resources/patches/gcc/aix-inclhack.patch" if platform.is_aix?
 

--- a/configs/components/gcc.rb
+++ b/configs/components/gcc.rb
@@ -1,6 +1,6 @@
 component "gcc" do |pkg, settings, platform|
   # Source-Related Metadata
-  if platform.name =~ /debian-9|el-7-aarch64|el-7-ppc64le|fedora-f24|fedora-f25|fedora-f26|fedora-f27|fedora-28|sles-12-ppc64le|ubuntu-16\.04-ppc64el|ubuntu-16\.10|ubuntu-18\.04/
+  if platform.name =~ /debian-9|el-7-aarch64|el-7-ppc64|fedora-f24|fedora-f25|fedora-f26|fedora-f27|fedora-28|sles-12-ppc64le|ubuntu-16\.04-ppc64el|ubuntu-16\.10|ubuntu-18\.04/
     pkg.version "6.1.0"
     pkg.md5sum "8d04cbdfddcfad775fdbc5e112af2690"
   elsif platform.is_aix? || platform.architecture == "s390x" || platform.architecture =~ /arm/
@@ -88,7 +88,7 @@ component "gcc" do |pkg, settings, platform|
       pkg.build_requires "g++"
       pkg.build_requires "libstdc++-dev"
       pkg.build_requires "libc6-dev"
-    when platform.architecture == "s390x" || platform.architecture == "ppc64le" || platform.architecture == "aarch64"
+    when platform.architecture == "s390x" || platform.architecture == "ppc64le" || platform.architecture == "aarch64" || platform.architecture == "ppc64"
       pkg.build_requires "pl-binutils-#{platform.architecture}"
       pkg.build_requires "sysroot"
       pkg.build_requires "libstdc++-devel"

--- a/configs/components/gdbm.rb
+++ b/configs/components/gdbm.rb
@@ -4,11 +4,11 @@ component "gdbm" do |pkg, settings, platform|
   pkg.md5sum "88770493c2559dc80b561293e39d3570"
   pkg.url "https://ftp.gnu.org/gnu/gdbm/gdbm-#{pkg.get_version}.tar.gz"
 
-  pkg.apply_patch "resources/patches/gdbm/0001-Mingw-port-of-gdbm-1.10.patch"
-
   prefix = settings[:prefix]
   if platform.is_windows?
     arch = platform.architecture == "x64" ? "64" : "32"
+
+    pkg.apply_patch "resources/patches/gdbm/0001-Mingw-port-of-gdbm-1.10.patch"
 
     pkg.environment "PATH" => "C:/tools/mingw#{arch}/bin:$$PATH"
     pkg.environment "CYGWIN" => "nodosfilewarning winsymlinks:native"

--- a/configs/components/gdbm.rb
+++ b/configs/components/gdbm.rb
@@ -2,7 +2,7 @@ component "gdbm" do |pkg, settings, platform|
 
   pkg.version "1.10"
   pkg.md5sum "88770493c2559dc80b561293e39d3570"
-  pkg.url "#{settings[:buildsources_url]}/gdbm-#{pkg.get_version}.tar.gz"
+  pkg.url "https://ftp.gnu.org/gnu/gdbm/gdbm-#{pkg.get_version}.tar.gz"
 
   pkg.apply_patch "resources/patches/gdbm/0001-Mingw-port-of-gdbm-1.10.patch"
 

--- a/configs/components/gdbm.rb
+++ b/configs/components/gdbm.rb
@@ -3,6 +3,7 @@ component "gdbm" do |pkg, settings, platform|
   pkg.version "1.10"
   pkg.md5sum "88770493c2559dc80b561293e39d3570"
   pkg.url "https://ftp.gnu.org/gnu/gdbm/gdbm-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/gdbm-#{pkg.get_version}.tar.gz"
 
   prefix = settings[:prefix]
   if platform.is_windows?

--- a/configs/components/gettext.rb
+++ b/configs/components/gettext.rb
@@ -13,6 +13,7 @@ component "gettext" do |pkg, settings, platform|
     end
 
     pkg.url "https://github.com/mlocati/gettext-iconv-windows/releases/download/v#{pkg.get_version}-v1.14/#{pkg.get_name}#{pkg.get_version}-iconv1.14-shared-#{arch}.zip"
+    pkg.mirror "#{settings[:buildsources_url]}/#{pkg.get_name}#{pkg.get_version}-iconv1.14-shared-#{arch}.zip"
 
     pkg.environment("PATH", "/cygdrive/c/tools/mingw#{arch}/bin:$(PATH):/cygdrive/c/ProgramData/chocolatey/tools")
     pkg.environment("CYGWIN", "nodosfilewarning winsymlinks:native")
@@ -30,6 +31,7 @@ component "gettext" do |pkg, settings, platform|
   else
     pkg.md5sum "97e034cf8ce5ba73a28ff6c3c0638092"
     pkg.url "http://ftp.gnu.org/gnu/#{pkg.get_name}/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+    pkg.mirror "#{settings[:buildsources_url]}/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
     if platform.is_aix?
       pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"

--- a/configs/components/gmp.rb
+++ b/configs/components/gmp.rb
@@ -3,4 +3,5 @@ component "gmp" do |pkg, settings, platform|
   pkg.version "4.3.2"
   pkg.md5sum "2a431d487dfd76d0f618d241b1e551cc"
   pkg.url "http://ftp.gnu.org/gnu/gmp/gmp-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/gmp-#{pkg.get_version}.tar.gz"
 end

--- a/configs/components/iconv.rb
+++ b/configs/components/iconv.rb
@@ -2,6 +2,7 @@ component "iconv" do |pkg, settings, platform|
   pkg.version "1.14"
   pkg.md5sum "e34509b1623cec449dfeb73d7ce9c6c6"
   pkg.url "http://ftp.gnu.org/gnu/lib#{pkg.get_name}/lib#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/lib#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   if platform.is_windows?
     arch = platform.architecture == "x64" ? "64" : "32"

--- a/configs/components/iconv.rb
+++ b/configs/components/iconv.rb
@@ -11,6 +11,11 @@ component "iconv" do |pkg, settings, platform|
     pkg.apply_patch "resources/patches/iconv/use-windows-paths.patch"
   end
 
+  # Ensure iconv compiles when glibc on the build machine is recent
+  # See this thread for detail: 
+  # https://lists.gnu.org/archive/html/bug-gnu-libiconv/2016-04/msg00001.html
+  pkg.apply_patch "resources/patches/iconv/check-glib-version.patch"
+
   pkg.configure do
     [" ./configure --prefix=#{settings[:prefix]} #{settings[:host]}"]
   end

--- a/configs/components/libffi.rb
+++ b/configs/components/libffi.rb
@@ -3,6 +3,7 @@ component "libffi" do |pkg, settings, platform|
   pkg.version "3.0.13"
   pkg.md5sum "45f3b6dbc9ee7c7dfbbbc5feba571529" # 3.0.13
   pkg.url "http://sourceware.org/pub/libffi/libffi-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/libffi-#{pkg.get_version}.tar.gz"
 
   pkg.apply_patch "resources/patches/libffi/0001-Includes-should-go-in-includedir-not-libdir.patch"
 

--- a/configs/components/libffi.rb
+++ b/configs/components/libffi.rb
@@ -2,7 +2,7 @@ component "libffi" do |pkg, settings, platform|
 
   pkg.version "3.0.13"
   pkg.md5sum "45f3b6dbc9ee7c7dfbbbc5feba571529" # 3.0.13
-  pkg.url "#{settings[:buildsources_url]}/libffi-#{pkg.get_version}.tar.gz"
+  pkg.url "http://sourceware.org/pub/libffi/libffi-#{pkg.get_version}.tar.gz"
 
   pkg.apply_patch "resources/patches/libffi/0001-Includes-should-go-in-includedir-not-libdir.patch"
 

--- a/configs/components/m4.rb
+++ b/configs/components/m4.rb
@@ -2,6 +2,7 @@ component "m4" do |pkg, settings, platform|
   pkg.version "1.4.17"
   pkg.md5sum "a5e9954b1dae036762f7b13673a2cf76"
   pkg.url "http://ftp.gnu.org/gnu/#{pkg.get_name}/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   if platform.is_aix?
     pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/make-3.80-1.aix5.1.ppc.rpm"

--- a/configs/components/make.rb
+++ b/configs/components/make.rb
@@ -2,6 +2,7 @@ component "make" do |pkg, settings, platform|
   pkg.version "4.1"
   pkg.md5sum "654f9117957e6fa6a1c49a8f08270ec9"
   pkg.url "http://ftp.gnu.org/gnu/make/make-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/make-#{pkg.get_version}.tar.gz"
 
   if platform.is_aix?
      pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-4.8.2-1.aix#{platform.os_version}.ppc.rpm"

--- a/configs/components/mpc.rb
+++ b/configs/components/mpc.rb
@@ -3,4 +3,5 @@ component "mpc" do |pkg, settings, platform|
   pkg.version "1.0.3"
   pkg.md5sum "d6a1d5f8ddea3abd2cc3e98f58352d26"
   pkg.url "http://ftp.gnu.org/gnu/mpc/mpc-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/mpc-#{pkg.get_version}.tar.gz"
 end

--- a/configs/components/mpfr.rb
+++ b/configs/components/mpfr.rb
@@ -3,4 +3,5 @@ component "mpfr" do |pkg, settings, platform|
   pkg.version "2.4.2"
   pkg.md5sum "0e3dcf9fe2b6656ed417c89aa9159428"
   pkg.url "http://ftp.gnu.org/gnu/mpfr/mpfr-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/mpfr-#{pkg.get_version}.tar.gz"
 end

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -24,9 +24,14 @@ component "openssl" do |pkg, settings, platform|
     make = "/usr/bin/make"
     pkg.environment "MAKE" => make
     prefix = platform.convert_to_windows_path(settings[:prefix])
-    cflags = settings[:cflags]
-    ldflags = settings[:ldflags]
   end
+
+  if platform.is_linux?
+    target = "linux-#{platform.architecture}"
+  end
+
+  cflags = settings[:cflags]
+  # ldflags = settings[:ldflags] - not currently used
 
   pkg.configure do
     [# OpenSSL Configure doesn't honor CFLAGS or LDFLAGS as environment variables.

--- a/configs/components/pdcurses.rb
+++ b/configs/components/pdcurses.rb
@@ -2,7 +2,7 @@ component "pdcurses" do |pkg, settings, platform|
 
   pkg.version "3.4"
   pkg.md5sum "4e04e4412d1b1392a7f9a489b95b331a"
-  pkg.url "#{settings[:buildsources_url]}/PDCurses-#{pkg.get_version}.tar.gz"
+  pkg.url "https://sourceforge.net/projects/pdcurses/files/pdcurses/#{pkg.get_version}/PDCurses-#{pkg.get_version}.tar.gz"
 
   makefile = "Makefile"
   if platform.is_windows?

--- a/configs/components/pdcurses.rb
+++ b/configs/components/pdcurses.rb
@@ -3,6 +3,7 @@ component "pdcurses" do |pkg, settings, platform|
   pkg.version "3.4"
   pkg.md5sum "4e04e4412d1b1392a7f9a489b95b331a"
   pkg.url "https://sourceforge.net/projects/pdcurses/files/pdcurses/#{pkg.get_version}/PDCurses-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/PDCurses-#{pkg.get_version}.tar.gz"
 
   makefile = "Makefile"
   if platform.is_windows?

--- a/configs/components/perl.rb
+++ b/configs/components/perl.rb
@@ -2,7 +2,7 @@ component "perl" do |pkg, settings, platform|
   pkg.version "5.26.2"
   pkg.md5sum "dc0fea097f3992a8cd53f8ac0810d523"
   pkg.url "https://www.cpan.org/src/5.0/perl-#{pkg.get_version}.tar.gz"
-  pkg.mirror "https://artifactory.delivery.puppetlabs.net/artifactory/generic__buildsources/buildsources/perl-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/perl-#{pkg.get_version}.tar.gz"
 
   pkg.configure do
     [ "sh Configure -de -Dprefix=#{settings[:prefix]}" ]

--- a/configs/components/pkg-config.rb
+++ b/configs/components/pkg-config.rb
@@ -1,7 +1,8 @@
 component "pkg-config" do |pkg, settings, platform|
   pkg.version "0.28"
-  pkg.url "http://pkgconfig.freedesktop.org/releases/pkg-config-#{pkg.get_version}.tar.gz"
   pkg.md5sum "aa3c86e67551adc3ac865160e34a2a0d"
+  pkg.url "http://pkgconfig.freedesktop.org/releases/pkg-config-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/pkg-config-#{pkg.get_version}.tar.gz"
 
   if platform.is_solaris?
     pkg.environment "PATH" => "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:/opt/csw/bin:$$PATH"

--- a/configs/components/pkg-config.rb
+++ b/configs/components/pkg-config.rb
@@ -1,6 +1,6 @@
 component "pkg-config" do |pkg, settings, platform|
   pkg.version "0.28"
-  pkg.url "http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz"
+  pkg.url "http://pkgconfig.freedesktop.org/releases/pkg-config-#{pkg.get_version}.tar.gz"
   pkg.md5sum "aa3c86e67551adc3ac865160e34a2a0d"
 
   if platform.is_solaris?

--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -2,6 +2,7 @@ component "ruby" do |pkg, settings, platform|
   pkg.version "2.1.9"
   pkg.md5sum "d9d2109d3827789344cc3aceb8e1d697"
   pkg.url "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/ruby-#{pkg.get_version}.tar.gz"
 
   pkg.apply_patch "resources/patches/ruby/libyaml_cve-2014-9130.patch"
 

--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -1,7 +1,7 @@
 component "ruby" do |pkg, settings, platform|
   pkg.version "2.1.9"
   pkg.md5sum "d9d2109d3827789344cc3aceb8e1d697"
-  pkg.url "#{settings[:buildsources_url]}/ruby-#{pkg.get_version}.tar.gz"
+  pkg.url "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-#{pkg.get_version}.tar.gz"
 
   pkg.apply_patch "resources/patches/ruby/libyaml_cve-2014-9130.patch"
 

--- a/configs/components/sysroot.rb
+++ b/configs/components/sysroot.rb
@@ -15,6 +15,9 @@ component "sysroot" do |pkg, settings, platform|
     when "el-7-s390x"
       pkg.version "2016.07.29"
       pkg.md5sum "8ce88d3df4c2c7f8a39ec46b0d78d88c"
+    when "el-7-ppc64"
+      pkg.version "2018.08.08"
+      pkg.md5sum "1fb328fecfe7cf8d940f6c11ddc613b7"
     when "el-7-ppc64le"
       pkg.version "2016.05.15"
       pkg.md5sum "5a31e65abf83ff077dd8bac797f193f4"
@@ -56,7 +59,7 @@ component "sysroot" do |pkg, settings, platform|
   puts "sysroot base is " + sysroot_base
 
   libdirs = "lib"
-  libdirs = "lib lib64" if platform.architecture == "s390x" || platform.name =~ /el-7-ppc64le|sles-12-ppc64le/ || platform.architecture == "aarch64"
+  libdirs = "lib lib64" if platform.architecture == "s390x" || platform.name =~ /el-7-ppc64|sles-12-ppc64le/ || platform.architecture == "aarch64"
   pkg.install do
     [
       "mv #{libdirs} #{sysroot_base}/",

--- a/configs/components/tar.rb
+++ b/configs/components/tar.rb
@@ -1,8 +1,9 @@
 component "tar" do |pkg, settings, platform|
   # Source-Related Metadata
   pkg.version "1.28"
-  pkg.url "http://ftp.gnu.org/gnu/tar/tar-1.28.tar.gz"
   pkg.md5sum "6ea3dbea1f2b0409b234048e021a9fd7"
+  pkg.url "http://ftp.gnu.org/gnu/tar/tar-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/tar-#{pkg.get_version}.tar.gz"
 
   # We run configure as root, which tar does not like
   pkg.environment "FORCE_UNSAFE_CONFIGURE" => "1"

--- a/configs/components/toolchain.rb
+++ b/configs/components/toolchain.rb
@@ -10,6 +10,7 @@ component "toolchain" do |pkg, settings, platform|
     elsif platform.name =~ /el-\d-x86_64|sles-\d\d-x86_64/
       # Toolchain files for rhel and sles running on IBM z-series, Power8, 
       # and aarch64, which builds on x86_64
+      pkg.add_source "file://files/cmake/el-ppc64-toolchain.cmake"
       pkg.add_source "file://files/cmake/el-ppc64le-toolchain.cmake"
       pkg.add_source "file://files/cmake/sles-ppc64le-toolchain.cmake"
       pkg.add_source "file://files/cmake/rhel-sles-s390x-toolchain.cmake"
@@ -70,10 +71,11 @@ component "toolchain" do |pkg, settings, platform|
     elsif platform.name =~ /el-\d-x86_64|sles-\d\d-x86_64/
       # Install toolchain files used by the s390x/Power8/aarch64 rhel and sles platfoms, which are built on x86_64
       pkg.install_file "rhel-sles-s390x-toolchain.cmake", "#{settings[:basedir]}/s390x-linux-gnu/pl-build-toolchain.cmake"
+      pkg.install_file "el-ppc64-toolchain.cmake", "#{settings[:basedir]}/ppc64-redhat-linux/pl-build-toolchain.cmake"
       pkg.install_file "el-ppc64le-toolchain.cmake", "#{settings[:basedir]}/ppc64le-redhat-linux/pl-build-toolchain.cmake"
       pkg.install_file "sles-ppc64le-toolchain.cmake", "#{settings[:basedir]}/powerpc64le-suse-linux/pl-build-toolchain.cmake"
       pkg.install_file "el-aarch64-toolchain.cmake", "#{settings[:basedir]}/aarch64-redhat-linux/pl-build-toolchain.cmake"
-	elsif platform.name =~ /ubuntu-16\.04-amd64/
+    elsif platform.name =~ /ubuntu-16\.04-amd64/
       # Install toolchain file used by the Power8 ubuntu platfom, which is built on amd64
       pkg.install_file "ubuntu-powerpc64le-toolchain.cmake", "#{settings[:basedir]}/powerpc64le-linux-gnu/pl-build-toolchain.cmake"
     end

--- a/configs/components/yaml-cpp.rb
+++ b/configs/components/yaml-cpp.rb
@@ -7,6 +7,7 @@ component "yaml-cpp" do |pkg, settings, platform|
   pkg.version "0.5.3"
   pkg.md5sum "2bba14e6a7f12c7272f87d044e4a7211"
   pkg.url "https://github.com/jbeder/yaml-cpp/archive/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   # Package Dependency Metadata
 
@@ -70,7 +71,7 @@ component "yaml-cpp" do |pkg, settings, platform|
   end
 
   # Build Commands
-  # 2018-09-04 - Note the addition of the c -r command to unroll yaml-cpp's
+  # 2018-09-04 - Note the addition of the cp -r command to unroll yaml-cpp's
   # annoying package-name doubling. It'd be nice if the maintainer would fix
   # this.
   pkg.build do

--- a/configs/components/yaml-cpp.rb
+++ b/configs/components/yaml-cpp.rb
@@ -1,13 +1,12 @@
 component "yaml-cpp" do |pkg, settings, platform|
   # Source-Related Metadata
-  if platform.architecture =~ /arm/ || platform.name =~ /fedora-f24/
-    pkg.version "0.5.3"
-    pkg.md5sum "9a60a3051c2ef01980c78a2d6be40ed9"
-  else
-    pkg.version "0.5.1"
-    pkg.md5sum "0fa47a5ed8fedefab766592785c85ee7"
-  end
-  pkg.url "#{settings[:buildsources_url]}/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  # Originally 0.5.3 was used exclusively for arm and fedora-f24. These sources
+  # don't seem to be available outside of puppetlab's internal artifactory
+  # system so I've bumped the release number to 0.5.3 for everything.
+  # 2018-09-04 - Phil DeMonaco
+  pkg.version "0.5.3"
+  pkg.md5sum "2bba14e6a7f12c7272f87d044e4a7211"
+  pkg.url "https://github.com/jbeder/yaml-cpp/archive/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   # Package Dependency Metadata
 
@@ -71,9 +70,13 @@ component "yaml-cpp" do |pkg, settings, platform|
   end
 
   # Build Commands
+  # 2018-09-04 - Note the addition of the c -r command to unroll yaml-cpp's
+  # annoying package-name doubling. It'd be nice if the maintainer would fix
+  # this.
   pkg.build do
     [ "rm -rf build-shared",
       "mkdir build-shared",
+      "cp -r ../yaml-cpp-yaml-cpp-0.5.3/* .",
       "cd build-shared",
       "#{special_path ? special_path : ''} \
       \"#{cmake}\" \

--- a/configs/components/zlib.rb
+++ b/configs/components/zlib.rb
@@ -2,7 +2,7 @@ component "zlib" do |pkg, settings, platform|
   # Source-Related Metadata
   pkg.version "1.2.8"
   pkg.md5sum "44d667c142d7cda120332623eab69f40"
-  pkg.url "#{settings[:buildsources_url]}/zlib-#{pkg.get_version}.tar.gz"
+  pkg.url "http://zlib.net/fossils/zlib-#{pkg.get_version}.tar.gz"
 
   # Package Dependency Metadata
 

--- a/configs/components/zlib.rb
+++ b/configs/components/zlib.rb
@@ -3,6 +3,7 @@ component "zlib" do |pkg, settings, platform|
   pkg.version "1.2.8"
   pkg.md5sum "44d667c142d7cda120332623eab69f40"
   pkg.url "http://zlib.net/fossils/zlib-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/zlib-#{pkg.get_version}.tar.gz"
 
   # Package Dependency Metadata
 

--- a/configs/platforms/el-7-ppc64.rb
+++ b/configs/platforms/el-7-ppc64.rb
@@ -1,0 +1,14 @@
+platform "el-7-ppc64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  # Currently unavailable - uncomment if/when puppet adds support for this
+  # internally.
+  #plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/7/ppc64/pl-build-tools-ppc64.repo"
+  #plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/7/x86_64/pl-build-tools-x86_64.repo"
+  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.install_build_dependencies_with "yum install --assumeyes"
+  plat.cross_compiled true
+  plat.vmpooler_template "redhat-7-x86_64"
+end

--- a/configs/projects/pl-build-tools.rb
+++ b/configs/projects/pl-build-tools.rb
@@ -22,6 +22,11 @@ elsif platform.architecture == "ppc64le"
   else
     platform_triple = "ppc64le-redhat-linux"
   end
+elsif platform.architecture == "ppc64"
+  # Adds big-endian powerpc support for RHEL.
+  if platform.name =~ /^el-/
+    platform_triple = "ppc64-redhat-linux"
+  end
 elsif platform.architecture == "aarch64" && platform.is_rpm?
   platform_triple = "aarch64-redhat-linux"
 elsif platform.architecture == "armhf"

--- a/configs/projects/pl-build-tools.rb
+++ b/configs/projects/pl-build-tools.rb
@@ -78,9 +78,3 @@ if platform.is_solaris?
 end
 
 proj.directory proj.basedir
-
-# Here we rewrite public http urls to use our internal source host instead.
-# Something like https://www.openssl.org/source/openssl-1.0.0r.tar.gz gets
-# rewritten as
-# https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/openssl-1.0.0r.tar.gz
-proj.register_rewrite_rule 'http', proj.buildsources_url

--- a/configs/projects/pl-gcc.rb
+++ b/configs/projects/pl-gcc.rb
@@ -4,7 +4,7 @@ project "pl-gcc" do |proj|
 
   proj.description "Puppet Labs GCC"
 
-  if platform.name =~ /debian-8-armel|debian-9|el-7-aarch64|el-7-ppc64le|fedora-f24|fedora-f25|fedora-f26|fedora-f27|fedora-28|sles-12-ppc64le|ubuntu-16\.04-ppc64el|ubuntu-16\.10|ubuntu-18\.04/
+  if platform.name =~ /debian-8-armel|debian-9|el-7-aarch64|el-7-ppc64|fedora-f24|fedora-f25|fedora-f26|fedora-f27|fedora-28|sles-12-ppc64le|ubuntu-16\.04-ppc64el|ubuntu-16\.10|ubuntu-18\.04/
     proj.version "6.1.0"
     proj.release "6"
   elsif platform.is_aix? || platform.architecture == "s390x" || platform.architecture =~ /arm/

--- a/configs/projects/pl-pkg-config.rb
+++ b/configs/projects/pl-pkg-config.rb
@@ -15,6 +15,4 @@ project "pl-pkg-config" do |proj|
 
   proj.component "pkg-config"
   proj.target_repo ""
-
-  proj.register_rewrite_rule 'http', proj.buildsources_url
 end

--- a/configs/projects/pl-rust.rb
+++ b/configs/projects/pl-rust.rb
@@ -10,6 +10,4 @@ project "pl-rust" do |proj|
   proj.homepage "https://www.puppetlabs.com"
   proj.component "rust"
   proj.target_repo ""
-
-  proj.register_rewrite_rule 'http', proj.buildsources_url
 end

--- a/configs/projects/pl-tar.rb
+++ b/configs/projects/pl-tar.rb
@@ -15,7 +15,4 @@ project "pl-tar" do |proj|
 
   proj.component "tar"
   proj.target_repo ""
-
-  proj.register_rewrite_rule 'http', proj.buildsources_url
-
 end

--- a/configs/projects/pl-yaml-cpp.rb
+++ b/configs/projects/pl-yaml-cpp.rb
@@ -3,13 +3,10 @@ project "pl-yaml-cpp" do |proj|
   instance_eval File.read('configs/projects/pl-build-tools.rb')
 
   proj.description "Puppet Yaml CPP"
-  if platform.architecture =~ /arm/ || platform.name =~ /fedora-f24/
-    proj.version "0.5.3"
-    proj.release "1"
-  else
-    proj.version "0.5.1"
-    proj.release "6"
-  end
+  # Bumping to version 0.5.3 as the default
+  proj.version "0.5.3"
+  proj.release "1"
+
   proj.license "MIT"
   proj.vendor "Puppet Labs <info@puppetlabs.com>"
   proj.homepage "https://www.puppetlabs.com"

--- a/files/cmake/el-ppc64-toolchain.cmake
+++ b/files/cmake/el-ppc64-toolchain.cmake
@@ -1,0 +1,42 @@
+# this one is important
+SET(CMAKE_SYSTEM_NAME Linux)
+# these ones not so much
+SET(CMAKE_SYSTEM_VERSION 1)
+SET(CMAKE_SYSTEM_PROCESSOR powerpc64)
+
+# specify the cross compiler
+SET(PL_TOOLS_ROOT        /opt/pl-build-tools)
+SET(PL_TOOLS_PREFIX      ${PL_TOOLS_ROOT}/ppc64-redhat-linux)
+SET(PL_TOOLS_SYSROOT     ${PL_TOOLS_PREFIX}/sysroot/lib)
+SET(CMAKE_C_COMPILER     ${PL_TOOLS_ROOT}/bin/ppc64-redhat-linux-gcc)
+SET(CMAKE_CXX_COMPILER   ${PL_TOOLS_ROOT}/bin/ppc64-redhat-linux-g++)
+SET(CMAKE_AR             ${PL_TOOLS_PREFIX}/bin/ar CACHE FILEPATH "Archiver")
+SET(CMAKE_LINKER         ${PL_TOOLS_ROOT}/bin/ppc64-redhat-linux-gcc CACHE PATH "Linker Program")
+SET(CMAKE_NM             ${PL_TOOLS_PREFIX}/bin/nm)
+
+# where is the target environment
+SET(CMAKE_FIND_ROOT_PATH ${PL_TOOLS_PREFIX})
+
+# search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+# for libraries and headers in the target directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ALWAYS)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ALWAYS)
+
+SET(CMAKE_C_FLAGS "-fPIC -pthread ${CMAKE_C_FLAGS}" CACHE STRING "" FORCE)
+SET(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS}" CACHE STRING "" FORCE)
+
+# update RPATH so our custom libraries can be found
+# use, i.e. don't skip the full RPATH for the build tree
+SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+
+# when building, don't use the install RPATH already
+# (but later on when installing)
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
+# add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)

--- a/resources/patches/iconv/check-glib-version.patch
+++ b/resources/patches/iconv/check-glib-version.patch
@@ -1,0 +1,13 @@
+--- ./srclib/stdio.in.h	2011-08-07 09:42:06.000000000 -0400
++++ ./srclib/stdio.in.h.fixed	2018-08-03 14:43:45.306723957 -0400
+@@ -695,8 +695,10 @@
+ /* It is very rare that the developer ever has full control of stdin,
+    so any use of gets warrants an unconditional warning.  Assume it is
+    always declared, since it is required by C89.  */
++#if defined(__GLIBC__) && !defined(__UCLIBC__) && !__GLIBC_PREREQ(2,16)
+ _GL_WARN_ON_USE (gets, "gets is a security hole - use fgets instead");
+ #endif
++#endif
+ 
+ 
+ #if @GNULIB_OBSTACK_PRINTF@ || @GNULIB_OBSTACK_PRINTF_POSIX@

--- a/scripts/generate_el-7-ppc64_sysroot.sh
+++ b/scripts/generate_el-7-ppc64_sysroot.sh
@@ -34,7 +34,7 @@ rm -r $sysrootdir/usr/lib64/{a,cracklib,d,e,f,g,k,libasound,libau,libavahi,libde
 
 # Since we're relocating the sysroot, we can't have absolute symlinks
 echo "Converting absolute library symlinks to relative ones..."
-pushd $sysrootdir/usr/lib64
+pushd $sysrootdir/usr/lib64 || exit
 find . -maxdepth 1 -lname '/*' |
 while read -r link ; do
   echo "Converting $link from absolute to relative..."
@@ -44,14 +44,14 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "$link"
 done
-popd
+popd || exit
 
 # On RHEL 7, /lib64 is a symlink to /usr/lib64. But we need to avoid
 # including any symlinks to directories to avoid packaging errors. So
 # convert any symlinks from ../../lib64/ to point to their targets, which are
 # in the current directory anyway.
 echo "Converting problematic library symlinks to local ones..."
-pushd $sysrootdir/usr/lib64
+pushd $sysrootdir/usr/lib64 || exit
 find . -maxdepth 1 -lname '../../lib64/*' |
 while read -r link ; do
   echo "Converting $link..."
@@ -61,7 +61,7 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "./$link"
 done
-popd
+popd || exit
 
 # ppc64 is a 64-bit platform and keeps those libs in /lib64 and /usr/lib64.
 # But when building gcc, you'll run into errors finding libraries if you

--- a/scripts/generate_el-7-ppc64_sysroot.sh
+++ b/scripts/generate_el-7-ppc64_sysroot.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+#
+# This script generates a sysroot tarball for the el-7-ppc64 (aka
+# Power 8) platform. For our builds we cross-compile most of our packages
+# on a redhat-7-x86_64 pooler system, but the sysroot must be created
+# from a native Power8 environment. Therefore, you must run this script
+# as root on a Power8 server running RHEL 7.2.
+
+sysrootdir="el-7-ppc64-sysroot"
+
+# First we remove a bunch of unneeded junk. The purpose of this is to try
+# to get rid of unneeded library files and minmize the size of the sysroot,
+# even though we'll still be pruning the libdirs in a later step.
+#
+# Note: we cannot remove libxml2-python, as it is in the dependency chain for
+# subscription-manager, which we need to keep the yum repos enabled for this
+# platform. 
+echo "Removing unneeded packages..."
+yum remove -y autofs cups-libs git-core libtiff libxslt mysql-libs opencryptoki-libs pango plymouth-core-libs python-lxml sssd-client samba-common systemtap-runtime
+
+echo "Installing critical libraries we need for building gcc and our various dependencies..."
+yum install --assumeyes rsync zlib-devel bzip2-devel libblkid-devel libcurl-devel libselinux-devel readline-devel e2fsprogs-devel xz-devel glibc-devel
+
+# Create a sysroot working area we can make further modifications to
+echo "Creating $sysrootdir and syncing sysroot directories under it..."
+rm -rf $sysrootdir
+mkdir -p $sysrootdir/usr
+rsync --archive /usr/lib64 $sysrootdir/usr/
+rsync --archive --copy-dirlinks /usr/include $sysrootdir/usr/
+
+echo "Pruning sysroot libdirs of unneeded files and directories..."
+# I always try to delete libnss* and libkrb*, but they're actually needed by libcurl, so don't do that:
+rm -r $sysrootdir/usr/lib64/{a,cracklib,d,e,f,g,k,libasound,libau,libavahi,libdev,libgio,libgnutls,liblvm,libmoz,libpython,librpm,libslang,libsoup,libsystemd,libX,libxcb,libxml,lua,m,NetworkManager,n,o,p,r,s,t,X11,x}*
+
+# Since we're relocating the sysroot, we can't have absolute symlinks
+echo "Converting absolute library symlinks to relative ones..."
+pushd $sysrootdir/usr/lib64
+find . -maxdepth 1 -lname '/*' |
+while read -r link ; do
+  echo "Converting $link from absolute to relative..."
+  target=$(readlink "$link")
+  # shellcheck disable=SC2001
+  reltarget=$(echo "$target" | sed 's|/lib64|../../lib64|g')
+  rm "$link"
+  ln -sf "$reltarget" "$link"
+done
+popd
+
+# On RHEL 7, /lib64 is a symlink to /usr/lib64. But we need to avoid
+# including any symlinks to directories to avoid packaging errors. So
+# convert any symlinks from ../../lib64/ to point to their targets, which are
+# in the current directory anyway.
+echo "Converting problematic library symlinks to local ones..."
+pushd $sysrootdir/usr/lib64
+find . -maxdepth 1 -lname '../../lib64/*' |
+while read -r link ; do
+  echo "Converting $link..."
+  target=$(readlink "$link")
+  # shellcheck disable=SC2001
+  reltarget=$(echo "$target" | sed 's|../../lib64/||g')
+  rm "$link"
+  ln -sf "$reltarget" "./$link"
+done
+popd
+
+# ppc64 is a 64-bit platform and keeps those libs in /lib64 and /usr/lib64.
+# But when building gcc, you'll run into errors finding libraries if you
+# use "lib64" in the sysroot, but also when using a sysroot that stored the
+# libraries in "lib" instead. A workaround to this is to just have both
+# directories.
+echo "Duplicating libdirs so both 'lib' and 'lib64' are available during compiles..."
+cp -a $sysrootdir/usr/lib64 $sysrootdir/lib64
+cp -a $sysrootdir/lib64 $sysrootdir/lib
+cp -a $sysrootdir/usr/lib64 $sysrootdir/usr/lib
+
+echo "Generating the sysroot tarball..."
+if [ -e $sysrootdir.tar.gz ]; then
+  rm $sysrootdir.tar.gz
+fi
+tar --create --gzip --file $sysrootdir.tar.gz --owner=0 --group=0 $sysrootdir
+
+echo "Done. Now copy $sysrootdir.tar.gz over to Artifactory."


### PR DESCRIPTION
Hello,

This is a rework of [pull request 55](https://github.com/puppetlabs/pl-build-tools-vanagon/pull/55) which should better comply with the commit guidelines. 

Note that this currently includes a number of `pkg.mirror` definitions and redundant calls to `proj.register_rewrite_rule 'http', proj.buildsources_url` which I believe are unnecessary. The rewrite rule definition in the pl-build-tools.rb should be sufficient as that file is included by all of the other projects.

I will be retesting the compilation process over the course of the day tomorrow using this updated branch.

Here's the high-level recap of changes from the original request:
* Added cross-compile support for el-7-ppc64
* Added working pkg.url entries for all components
* Removed redundant mirror entries which were already handled by the rewrite rule 
* Added a patch for iconv 1.14 to correct a build failure when the glibc of the build machine was too new
* Fixed an issue in the OpenSSL build component where a patch related to windows builds caused my ppc64 build to fail. 

Also, I had to make a minor change to the build process for the yaml-cpp package because it's maintainer names their revisions in an irritating manner. I think the internal artifactory system in use by puppetlabs might be correcting for this by repackaging that file. In the process I bumped the version from 0.5.1 to 0.5.3 for all platforms.

Phil