### PR TITLE
Use docker for testing on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
 language: bash
 
-# Use container-based infrastructure for quicker build start-up
-sudo: false
+sudo: required
 
-addons:
-  apt:
-    sources:
-    - debian-sid  # Grab shellcheck from the Debian repo (o_O)
-    packages:
-    - shellcheck
+services:
+  - docker
+
+before_install:
+  - docker build -t ci-test-img .
 
 script:
-  - bash -c 'find . -type f -name "*.sh"  | xargs shellcheck'
+  - docker run ci-test-img
 
 matrix:
   fast_finish: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:cosmic
+
+RUN apt-get update
+RUN apt-get -y install shellcheck
+COPY . /pl-build-tools-vanagon/
+CMD /bin/bash -c 'find /pl-build-tools-vanagon/ -type f -name "*.sh"  | xargs shellcheck'

--- a/scripts/generate_debian_sysroot.sh
+++ b/scripts/generate_debian_sysroot.sh
@@ -42,7 +42,7 @@ if [ -z "$1" ] ; then
     chroot debian-${DEBIANVER}-${ARCH}-sysroot /bin/bash "${0}" chroot
     rm -rf debian-${DEBIANVER}-${ARCH}-sysroot/usr/bin
     rm -rf debian-${DEBIANVER}-${ARCH}-sysroot/bin
-    find debian-${DEBIANVER}-${ARCH}-sysroot -maxdepth 2 -mindepth 1 -type d  | egrep -v 'usr|lib'
+    find debian-${DEBIANVER}-${ARCH}-sysroot -maxdepth 2 -mindepth 1 -type d  | grep -E -v 'usr|lib'
     tar czf debian-${DEBIANVER}-${ARCH}-sysroot.tar.gz --owner=0 --group=0 debian-${DEBIANVER}-${ARCH}-sysroot
 fi
 

--- a/scripts/generate_el-6-s390x_sysroot.sh
+++ b/scripts/generate_el-6-s390x_sysroot.sh
@@ -37,7 +37,7 @@ rm -r $sysrootdir/usr/lib64/{a,b,coreutils,cracklib,crash,d,e,g,h,k,ldb,libnssck
 
 # Since we're relocating the sysroot, we can't have absolute symlinks
 echo "Converting absolute library symlinks to relative ones..."
-pushd $sysrootdir/usr/lib64
+pushd $sysrootdir/usr/lib64 || exit
 find . -maxdepth 1 -lname '/*' |
 while read -r link ; do
   echo "Converting $link from absolute to relative..."
@@ -47,7 +47,7 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "$link"
 done
-popd
+popd || exit
 
 # s390x is a 64-bit platform and keeps those libs in /lib64 and /usr/lib64.
 # But when building gcc, you'll run into errors finding libraries if you

--- a/scripts/generate_el-7-aarch64_sysroot.sh
+++ b/scripts/generate_el-7-aarch64_sysroot.sh
@@ -34,7 +34,7 @@ rm -r $sysrootdir/usr/lib64/{a,cracklib,d,e,f,g,k,libasound,libau,libavahi,libde
 
 # Since we're relocating the sysroot, we can't have absolute symlinks
 echo "Converting absolute library symlinks to relative ones..."
-pushd $sysrootdir/usr/lib64
+pushd $sysrootdir/usr/lib64 || exit
 find . -maxdepth 1 -lname '/*' |
 while read -r link ; do
   echo "Converting $link from absolute to relative..."
@@ -44,14 +44,14 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "$link"
 done
-popd
+popd || exit
 
 # On RHEL 7, /lib64 is a symlink to /usr/lib64. But we need to avoid
 # including any symlinks to directories to avoid packaging errors. So
 # convert any symlinks from ../../lib64/ to point to their targets, which are
 # in the current directory anyway.
 echo "Converting problematic library symlinks to local ones..."
-pushd $sysrootdir/usr/lib64
+pushd $sysrootdir/usr/lib64 || exit
 find . -maxdepth 1 -lname '../../lib64/*' |
 while read -r link ; do
   echo "Converting $link..."
@@ -61,7 +61,7 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "./$link"
 done
-popd
+popd || exit
 
 # AArch64 is a 64-bit platform and keeps those libs in /lib64 and /usr/lib64.
 # But when building gcc, you'll run into errors finding libraries if you

--- a/scripts/generate_el-7-ppc64le_sysroot.sh
+++ b/scripts/generate_el-7-ppc64le_sysroot.sh
@@ -34,7 +34,7 @@ rm -r $sysrootdir/usr/lib64/{a,cracklib,d,e,f,g,k,libasound,libau,libavahi,libde
 
 # Since we're relocating the sysroot, we can't have absolute symlinks
 echo "Converting absolute library symlinks to relative ones..."
-pushd $sysrootdir/usr/lib64
+pushd $sysrootdir/usr/lib64 || exit
 find . -maxdepth 1 -lname '/*' |
 while read -r link ; do
   echo "Converting $link from absolute to relative..."
@@ -44,14 +44,14 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "$link"
 done
-popd
+popd || exit
 
 # On RHEL 7, /lib64 is a symlink to /usr/lib64. But we need to avoid
 # including any symlinks to directories to avoid packaging errors. So
 # convert any symlinks from ../../lib64/ to point to their targets, which are
 # in the current directory anyway.
 echo "Converting problematic library symlinks to local ones..."
-pushd $sysrootdir/usr/lib64
+pushd $sysrootdir/usr/lib64 || exit
 find . -maxdepth 1 -lname '../../lib64/*' |
 while read -r link ; do
   echo "Converting $link..."
@@ -61,7 +61,7 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "./$link"
 done
-popd
+popd || exit
 
 # ppc64le is a 64-bit platform and keeps those libs in /lib64 and /usr/lib64.
 # But when building gcc, you'll run into errors finding libraries if you

--- a/scripts/generate_el-7-s390x_sysroot.sh
+++ b/scripts/generate_el-7-s390x_sysroot.sh
@@ -35,7 +35,7 @@ rm -r $sysrootdir/usr/lib64/{a,cifs,colord,cracklib,d,e,f,g,k,ldb,libasound,libd
 
 # Since we're relocating the sysroot, we can't have absolute symlinks
 echo "Converting absolute library symlinks to relative ones..."
-pushd $sysrootdir/usr/lib64
+pushd $sysrootdir/usr/lib64 || exit
 find . -maxdepth 1 -lname '/*' |
 while read -r link ; do
   echo "Converting $link from absolute to relative..."
@@ -45,14 +45,14 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "$link"
 done
-popd
+popd || exit
 
 # On RHEL 7, /lib64 is a symlink to /usr/lib64. But we need to avoid
 # including any symlinks to directories to avoid packaging errors. So
 # convert any symlinks from ../../lib64/ to point to their targets, which are
 # in the current directory anyway.
 echo "Converting problematic library symlinks to local ones..."
-pushd $sysrootdir/usr/lib64
+pushd $sysrootdir/usr/lib64 || exit
 find . -maxdepth 1 -lname '../../lib64/*' |
 while read -r link ; do
   echo "Converting $link..."
@@ -62,7 +62,7 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "./$link"
 done
-popd
+popd || exit
 
 # s390x is a 64-bit platform and keeps those libs in /lib64 and /usr/lib64.
 # But when building gcc, you'll run into errors finding libraries if you

--- a/scripts/generate_sles-11-s390x_sysroot.sh
+++ b/scripts/generate_sles-11-s390x_sysroot.sh
@@ -38,7 +38,7 @@ rm -r $sysrootdir/usr/lib64/{a,b,coreutils,crash,cups,e,g,h,k,ldscripts,libblas,
 
 # Since we're relocating the sysroot, we can't have absolute symlinks
 echo "Converting absolute library symlinks to relative ones..."
-pushd $sysrootdir/usr/lib64
+pushd $sysrootdir/usr/lib64 || exit
 find . -maxdepth 1 -lname '/*' |
 while read -r link ; do
   echo "Converting $link from absolute to relative..."
@@ -48,9 +48,9 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "$link"
 done
-popd
+popd || exit
 
-pushd $sysrootdir/usr/lib64/ncurses6
+pushd $sysrootdir/usr/lib64/ncurses6 || exit
 find . -maxdepth 1 -lname '/*' |
 while read -r link ; do
   echo "Converting $link from absolute to relative..."
@@ -60,7 +60,7 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "$link"
 done
-popd
+popd || exit
 
 # s390x is a 64-bit platform and keeps those libs in /lib64 and /usr/lib64.
 # But when building gcc, you'll run into errors finding libraries if you

--- a/scripts/generate_sles-12-ppc64le_sysroot.sh
+++ b/scripts/generate_sles-12-ppc64le_sysroot.sh
@@ -64,7 +64,7 @@ rm -rf $SYSROOTDIR/usr/lib64/x*
 
 # Since we're relocating the sysroot, we can't have absolute symlinks
 echo "Converting absolute library symlinks to relative ones..."
-pushd $SYSROOTDIR/lib64
+pushd $SYSROOTDIR/lib64 || exit
 find . -maxdepth 1 -lname '/*' |
 while read -r link ; do
   echo "Converting $link from absolute to relative..."
@@ -74,9 +74,9 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "$link"
 done
-popd
+popd || exit
 
-pushd $SYSROOTDIR/usr/lib64
+pushd $SYSROOTDIR/usr/lib64 || exit
 find . -maxdepth 1 -lname '/*' |
 while read -r link ; do
   echo "Converting $link from absolute to relative..."
@@ -86,9 +86,9 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "$link"
 done
-popd
+popd || exit
 
-pushd $SYSROOTDIR/usr/lib64/ncurses6
+pushd $SYSROOTDIR/usr/lib64/ncurses6 || exit
 find . -maxdepth 1 -lname '/*' |
 while read -r link ; do
   echo "Converting $link from absolute to relative..."
@@ -98,7 +98,7 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "$link"
 done
-popd
+popd || exit
 
 # RPM on SLES doesn't scoop up sylinks to directories, they must be added
 # via specfile entries. Since we're adding the sysroot to the pl-gcc RPM,

--- a/scripts/generate_sles-12-s390x_sysroot.sh
+++ b/scripts/generate_sles-12-s390x_sysroot.sh
@@ -78,7 +78,7 @@ rm -rf $SYSROOTDIR/usr/lib64/Y*
 
 # Since we're relocating the sysroot, we can't have absolute symlinks
 echo "Converting absolute library symlinks to relative ones..."
-pushd $SYSROOTDIR/lib64
+pushd $SYSROOTDIR/lib64 || exit
 find . -maxdepth 1 -lname '/*' |
 while read -r link ; do
   echo "Converting $link from absolute to relative..."
@@ -88,9 +88,9 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "$link"
 done
-popd
+popd || exit
 
-pushd $SYSROOTDIR/usr/lib64
+pushd $SYSROOTDIR/usr/lib64 || exit
 find . -maxdepth 1 -lname '/*' |
 while read -r link ; do
   echo "Converting $link from absolute to relative..."
@@ -100,9 +100,9 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "$link"
 done
-popd
+popd || exit
 
-pushd $SYSROOTDIR/usr/lib64/ncurses6
+pushd $SYSROOTDIR/usr/lib64/ncurses6 || exit
 find . -maxdepth 1 -lname '/*' |
 while read -r link ; do
   echo "Converting $link from absolute to relative..."
@@ -112,7 +112,7 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "$link"
 done
-popd
+popd || exit
 
 # RPM on SLES doesn't scoop up sylinks to directories, they must be added
 # via specfile entries. Since we're adding the sysroot to the pl-gcc RPM,

--- a/scripts/generate_ubuntu-16.04-ppc64el_sysroot.sh
+++ b/scripts/generate_ubuntu-16.04-ppc64el_sysroot.sh
@@ -37,7 +37,7 @@ rm -r $sysrootdir/usr/lib/$triple/{audit,gconv,krb,openssl,perl}*
 
 # Since we're relocating the sysroot, we can't have absolute symlinks
 echo "Converting absolute library symlinks to relative ones..."
-pushd $sysrootdir/usr/lib/$triple
+pushd $sysrootdir/usr/lib/$triple || exit
 find . -maxdepth 1 -lname '/*' |
 while read -r link ; do
   echo "Converting $link from absolute to relative..."
@@ -47,7 +47,7 @@ while read -r link ; do
   rm "$link"
   ln -sf "$reltarget" "$link"
 done
-popd
+popd || exit
 
 # We duplicate the Debian multilib libraries into lib/ in the sysroot due
 # to the fact that leatherman does not yet fully support Debian-style
@@ -55,7 +55,7 @@ popd
 cp -a $sysrootdir/lib/$triple/* $sysrootdir/lib/
 # Likewise, an extra step is needed here to consolidate header files to avoid
 # the same problems with multilib path searching:
-rsync --archive --copy-dirlinks $sysroot/usr/include/$triple/ $sysrootdir/usr/include/
+rsync --archive --copy-dirlinks $sysrootdir/usr/include/$triple/ $sysrootdir/usr/include/
 
 echo "Generating the sysroot tarball..."
 if [ -e $sysrootdir.tar.gz ]; then


### PR DESCRIPTION
By default Travis uses Ubuntu 14.04 to run tests. 
It seems like the libc6-dev package is broken on the debian-sid repository for ubuntu 14.04. libc6-dev is required for shellcheck.

This PR attempts to fix the travis CI job by building a docker image from ubuntu 18.04 and running the shellcheck on that image. 

Travis has no plans to support Ubuntu 16.04 and ubuntu 18.04 in the near future: https://github.com/travis-ci/travis-ci/issues/5821.

This PR also fixes the following errors:
- SC2164 for pushd and popd (https://github.com/koalaman/shellcheck/wiki/SC2164)
- SC2196 https://github.com/koalaman/shellcheck/wiki/SC2196
- $sysroot wrong variable name https://github.com/puppetlabs/pl-build-tools-vanagon/pull/58/commits/53e3c78bd748577279b749f9b78dee693abf735c#diff-0df3d41a6497e3835edd245c3c32fc8cR58