### PR TITLE
Revert "(maint) Update pl-cmake to 3.12.4 for Solaris"

### DIFF
--- a/configs/components/cmake.rb
+++ b/configs/components/cmake.rb
@@ -1,19 +1,15 @@
 component "cmake" do |pkg, settings, platform|
   # Source-Related Metadata
-  if platform.is_solaris?
-    pkg.version "3.12.4"
-    pkg.url "https://cmake.org/files/v3.12/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
-    pkg.md5sum "4970869480ee37c8f4c8e7f83c4359cd"
-  else
-    pkg.version "3.2.3"
-    pkg.url "https://cmake.org/files/v3.2/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
-    pkg.md5sum "d51c92bf66b1e9d4fe2b7aaedd51377c"
-  end
+  pkg.version "3.2.3"
+  pkg.md5sum "d51c92bf66b1e9d4fe2b7aaedd51377c"
+  pkg.url "https://cmake.org/files/v3.2/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   pkg.mirror "#{settings[:buildsources_url]}/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   if platform.name =~ /sles-12/
     pkg.apply_patch 'resources/patches/cmake/avoid-select-sles-12.patch'
+  elsif platform.is_solaris?
+    pkg.apply_patch 'resources/patches/cmake/use-g++-as-linker-solaris.patch'
   end
 
   # Package Dependency Metadata

--- a/configs/projects/pl-cmake.rb
+++ b/configs/projects/pl-cmake.rb
@@ -3,10 +3,7 @@ project "pl-cmake" do |proj|
   instance_eval File.read('configs/projects/pl-build-tools.rb')
 
   proj.description "Puppet Labs cmake"
-  if platform.is_solaris?
-    proj.version "3.12.4"
-    proj.release "1"
-  elsif platform.name =~ /debian-8-armel/
+  if platform.name =~ /debian-8-armel/
     proj.version "3.5.2"
     proj.release "5"
   else

--- a/resources/patches/cmake/use-g++-as-linker-solaris.patch
+++ b/resources/patches/cmake/use-g++-as-linker-solaris.patch
@@ -1,0 +1,34 @@
+From 60fe4b540b40330e050dbd755204cecbc62d6a37 Mon Sep 17 00:00:00 2001
+From: Brad King <brad.king@kitware.com>
+Date: Thu, 30 Jul 2015 13:57:22 -0400
+Subject: [PATCH] SunOS: Drop special case for linking C++ shared libraries
+ with gcc (#15673)
+
+Since commit v2.4.0~4325 (...use gcc -shared, even for C++ libraries,
+2003-03-13) we use the C compiler "gcc" to link C++ shared libraries
+compiled with "g++".  At the time "g++" did not know how to link shared
+libraries correctly.  This has long since been fixed so simply drop the
+special case.
+---
+ Modules/Platform/SunOS.cmake | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/Modules/Platform/SunOS.cmake b/Modules/Platform/SunOS.cmake
+index aaa79c4..77946f2 100644
+--- a/Modules/Platform/SunOS.cmake
++++ b/Modules/Platform/SunOS.cmake
+@@ -7,14 +7,6 @@ if(CMAKE_SYSTEM MATCHES "SunOS-4")
+    set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG_SEP ":")
+ endif()
+ 
+-if(CMAKE_COMPILER_IS_GNUCXX)
+-  if(CMAKE_COMPILER_IS_GNUCC)
+-    set(CMAKE_CXX_CREATE_SHARED_LIBRARY
+-        "<CMAKE_C_COMPILER> <CMAKE_SHARED_LIBRARY_CXX_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS>  <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>")
+-  else()
+-    # Take default rule from CMakeDefaultMakeRuleVariables.cmake.
+-  endif()
+-endif()
+ include(Platform/UnixPaths)
+ 
+ # Add the compiler's implicit link directories.


### PR DESCRIPTION
Reverts puppetlabs/pl-build-tools-vanagon#66

This produced some egregious linking errors during leatherman builds for solaris 11 on SPARC for puppet-agent 5.5.x. It seems like the path of least resistance here is to revert this change, accept the older version of cmake everywhere, and adapt the master branch of puppet-agent to use a more backwards-compatible alternative to `add_compile_definitions`.