### PR TITLE
Allow Gemfile to use https: sources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 def location_for(place)
-  if place =~ /^(git[:@][^#]*)#(.*)/
+  if place =~ /^((?:git[:@]|https:)[^#]*)#(.*)/
     [{ :git => $1, :branch => $2, :require => false }]
   elsif place =~ /^file:\/\/(.*)/
     ['>= 0', { :path => File.expand_path($1), :require => false }]


### PR DESCRIPTION
Prior to this patch, the Gemfile only allowed VANAGON_LOCATION and
PACKAGING_LOCATION to be sources starting with `git@` or `git:`.
This patch adds `https:` as an option so that repos carrying patches
can be accessed without configuring SSH keys.