### PR TITLE
(RE-13434) Remove old GPG key from build_defaults.yaml

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,7 +1,6 @@
 ---
 project: 'pl-build-tools'
 gpg_name: 'info@puppetlabs.com'
-gpg_key: '7F438280EF8D349F'
 sign_tar: FALSE
 vanagon_project: TRUE
 build_tar: FALSE


### PR DESCRIPTION
The `gpg_key` setting is overridden by `build-data`. Removing the
local, soon-to-be-expired key from `build_defaults.yaml` for clarity
and cleanliness.