### PR TITLE
(maint) Use focal instead of cosmic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:cosmic
+FROM ubuntu:focal
 
 RUN apt-get update
 RUN apt-get -y install shellcheck


### PR DESCRIPTION
Travis CI was failing trying to pull the ubuntu cosmic 18.10 image which is EOL.
