### PR TITLE
(PE-34232) Update ruby to 2.5.9

### DIFF
--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -1,7 +1,7 @@
 component "ruby" do |pkg, settings, platform|
-  pkg.version "2.1.9"
-  pkg.md5sum "d9d2109d3827789344cc3aceb8e1d697"
-  pkg.url "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-#{pkg.get_version}.tar.gz"
+  pkg.version "2.5.9"
+  pkg.sha56sum "f5894e05f532b748c3347894a5efa42066fd11cc8d261d4d9788ff71da00be68"
+  pkg.url "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-#{pkg.get_version}.tar.gz"
   pkg.mirror "#{settings[:buildsources_url]}/ruby-#{pkg.get_version}.tar.gz"
 
   pkg.apply_patch "resources/patches/ruby/libyaml_cve-2014-9130.patch"

--- a/configs/projects/pl-ruby.rb
+++ b/configs/projects/pl-ruby.rb
@@ -7,8 +7,8 @@ project "pl-ruby" do |proj|
   proj.license "2 Clause BSD"
   proj.vendor "Puppet Labs <info@puppetlabs.com>"
   proj.homepage "https://www.puppetlabs.com"
-  proj.version "2.1.9"
-  proj.release "4"
+  proj.version "2.5.9"
+  proj.release "5"
 
   # Platform specific - these flags do not work on AIX
   unless platform.is_aix?


### PR DESCRIPTION
I'm not sure this is something we should be merging at this point in the PE release-cycle, but I wanted to get it opened for comments