### PR TITLE
(RE-14662) Create pl-gcc 12.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,16 @@
-source ENV['GEM_SOURCE'] || "https://rubygems.org"
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 def location_for(place)
   if place =~ /^((?:git[:@]|https:)[^#]*)#(.*)/
-    [{ :git => $1, :branch => $2, :require => false }]
+    [{ git: $1, branch: $2, require: false }]
   elsif place =~ /^file:\/\/(.*)/
-    ['>= 0', { :path => File.expand_path($1), :require => false }]
+    ['>= 0', { path: File.expand_path($1), require: false }]
   elsif place =~ /(\d+\.\d+\.\d+)/
-    [place, { :require => false }]
+    [place, { require: false }]
   end
 end
 
 gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.21')
-gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99.4')
+gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.100')
 gem 'json'
 gem 'rake'

--- a/README-internal.md
+++ b/README-internal.md
@@ -4,12 +4,9 @@ This README doc is only relevant to employees of Puppet, Inc. who are using our 
 
 ## Shipping to production
 
-When your packages have been tested and are ready for use, you can ship them to our internal production pl-build-tools package repositories. Start by pulling in our packaging repo and ensuring it's up to date with:
+When packages have been tested and are ready for use, ship them to the internal production pl-build-tools package repositories.
 
-        bundle exec rake package:implode
-        bundle exec rake pacakge:bootstrap
-
-Then you can ship the package with:
+Ship the package with:
 
         bundle exec ship
         bundle exec rake pl:jenkins:uber_ship
@@ -22,31 +19,33 @@ https://confluence.puppetlabs.com/display/RE/pl-build-tools+shipping+process
 
 ## Shipping to pl-build-tools-staging
 
-When building out major new features (e.g, upgrading our GCC toolchain), we use a staging area and repos to avoid breaking the production area while we're working out highly interdependent bugs in our pl-build-tools packages. You can ship to the staging area by setting the `DEV_BUILD` environment variable to true when running the `uber_ship` task:
+When building new features (like upgrading the GCC toolchain), we use a staging area and repos to avoid breaking the production area while we're working out bugs in the pl-build-tools packages.
+
+Ship to the staging area by setting the `DEV_BUILD` environment variable to true when running the `uber_ship` task:
 
 	rake pl:jenkins:uber_ship DEV_BUILD=true
 
-Note: this currently only works for Deb and RPM based platforms. It has not yet been tested with DMG/SWIX/IPS/MSI platforms.
+Note that this currently only works for Deb and RPM based platforms.
 
 # Building pl-build-tools With Jenkins
 
-For testing and validation purposes, you can kick off builds from this repository using the [Jenkins Dynamic Vanagon Builder](http://jenkins-release.delivery.puppetlabs.net/job/vanagon_generic_job/).
+For testing and validation purposes, trigger builds from this repository using the [Jenkins Dynamic Vanagon Builder](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder).
 
 ## Platforms
 
-These are the platforms you'll build your package for. A default list has been provided, but there is no guarantee that it will be up to date, or build all the platforms you care about. Make sure you edit this list to contain the build targets you want. 
+This is a list of target platforms for the package. A default list has been provided, but there is no guarantee that it will be correct. Edit this list to contain the build targets you want.
 
 ## Project
 
-This is the name of the project you're building (e.g, pl-gcc). It corresponds to a project file in the `configs/projects` directory of the repo.
+This is the name of the project to be built (`pl-gcc`, for example). It corresponds to a project file in the `configs/projects` directory in this source repository.
 
 ## Repo
 
-This is the repo where your vanagon project lives. Although this jenkins job was created to make building pl-build-tools-vanagon projects simpler, it can technically be used to build any vanagon project. 
+This is the repo where your vanagon project lives. In this case `pl-build-tools-vanagon`.
 
 ## Branch
 
-This is the branch you want to build from. This is especially useful when building a topic branch for testing. If you are building from a custom branch, specify `origin/branch_name` for clarity. If you are building from a tag, use `refs/tags/tag_name`. If you are building from a SHA reference, use `sha`.
+This is the branch in the Repo to build. To build from a custom branch, specify `origin/branch_name` for clarity. To build from a tag, use `refs/tags/tag_name`. To build from an arbitrary sha, just list the sha alone.
 
 # Building for AIX
 
@@ -54,22 +53,24 @@ AIX is a special snowflake.
 
 ## Overall
 
-Our AIX boxes also have small filesystems. When buildling larger projects (like gcc), you might need to expand some filesystems.
+The AIX boxes also have small filesystems. When buildling larger projects (like gcc), some filesystems likely will need to be expanded:
 
 	chfs -a size=+2G /
 	chfs -a size=+1G /tmp
 	chfs -a size=+1G /opt
 
-Right now, since AIX isn't a special engine or anything, we're just using an LPAR ssh target to build. This means, you need to clean up your mess when you're done. Normally this means removing quite a few files in /root and wherever your installation path is (/opt/pl-build-tools or /opt/puppetlabs).  You also might need to uninstall some rpms.
+AIX isn't a special engine, so we're just using an LPAR ssh target to build. This means that manual post-build cleanup is required. Normally this means removing quite a few files in /root and wherever the installation path is (/opt/pl-build-tools or /opt/puppetlabs) and removing any RPMs that were installed.
 
 Obviously this could (and should) be improved.
 
 ## GCC
 
-To build gcc, you have to build an intermediate GCC. There is a boostrapping GCC rpm available at http://pl-build-tools.delivery.puppetlabs.net/aix/6.1/ppc/gcc-aix-boostrap-4.6.4-1.aix6.1.ppc.rpm.
-That rpm should be installed to bootstrap any GCC >= 4.8. Beyond that, to build you'll need to export two env variables in the project a few ways.
+To build gcc, you must build an intermediate GCC. There is a boostrapping GCC rpm available at http://pl-build-tools.delivery.puppetlabs.net/aix/6.1/ppc/gcc-aix-boostrap-4.6.4-1.aix6.1.ppc.rpm.
+That rpm should be installed to bootstrap any GCC >= 4.8.
+
+Then, two environment variables are required to use the intermedidate:
 
 	export CC=/opt/gcc464/bin/gcc
 	export CXX=/opt/gcc464/bin/g++
 
-Once you do that, (you can do this by uncommenting the lines in the aix-61-ppc definition), you *should* be able to build GCC 4.8.2 for AIX 6.1 and 7.1. AIX 5.3 will likely be a more involved and difficult process and we just haven't made it there yet.
+With that, building GCC *should* work for for AIX 6.1 and 7.1. AIX 5.3 will likely be a more involved and difficult process and we just haven't made it there yet.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ At Puppet Inc, we ship these packages to repositories on our internal network on
 
 # Available projects
 
-The tools and libraries you can build using this repository can be found in the [`configs/projects/`](configs/projects) directory. For example:
+The tools and libraries you can build using this repository can be found in the [`configs/projects`](configs/projects) directory. For example:
 
 * pl-gcc
 * pl-boost (build requires pl-gcc)
@@ -17,11 +17,11 @@ The tools and libraries you can build using this repository can be found in the 
 
 ...and others.
 
-These projects all generate packages with a "pl-" prefix (for Puppet Labs) and are installed under `/opt/pl-build-tools/` so that they do not conflict with equivalent system packages. Note that not all projects are guaranteed to successfully build on every platform listed in [`configs/platforms/`](configs/platforms).
+These projects all generate packages with a "pl-" prefix (for Puppet Labs) and are installed under `/opt/pl-build-tools` so that they do not conflict with equivalent system packages. Note that not all projects are guaranteed to successfully build on every platform listed in [`configs/platforms`](configs/platforms).
 
 # Setting Up Your Build Environment
 
-A modern Linux or Mac OS X operating system with a recent version of Ruby (1.9 or later) with the bundler gem is required to run these builds. 
+A modern Linux or Mac OS X operating system with a recent version of Ruby (1.9 or later) with the bundler gem is required to run these builds.
 
 This repository makes use of the [Vanagon](https://github.com/puppetlabs/vanagon) build system, which is written in Ruby. The [Gemfile](https://github.com/puppetlabs/pl-build-tools-vanagon/blob/master/Gemfile) included in this repo specifies all of the needed ruby libraries to build a target project. Additionally, vanagon requires a virtualization engine to build target packages in. More information on the different virtualization engine options is available in the vanagon repo.
 
@@ -31,7 +31,7 @@ Begin by cloning this repository:
 
 and install the required Ruby gems with the `bundle install` command:
 
-	cd pl-build-tools-vanagon/
+	cd pl-build-tools-vanagon
 	bundle install
 
 ## Using `VANAGON_LOCATION` to specify a custom Vanagon source
@@ -39,7 +39,7 @@ and install the required Ruby gems with the `bundle install` command:
 By default, our [Gemfile](https://github.com/puppetlabs/pl-build-tools-vanagon/blob/master/Gemfile) specifies a particular version of Vanagon (typically, the latest master branch checked out from the vanagon GitHub repo). There are times where you may wish to use a customized version of vanagon from a git repository branch, or a copy of Vanagon stored locally on your filesystem. You can do this by setting the environment variable `VANAGON_LOCATION` when running bundle install:
 
 * `0.3.14` - Use a specific git tag from the Vanagon git repo
-* `git@github.com:puppetlabs/vanagon#master` - Customize the remote git location and/or branch
+* `git@github.com:puppetlabs/vanagon#main` - Customize the remote git location and/or branch
 * `file:///workspace/vanagon` - Absolute file path
 * `file://../vanagon` - File path relative to the project directory
 
@@ -59,28 +59,28 @@ The `build` command above comes from the vanagon gem, and it has a number of pos
 
 ### project name
 
-The name of the project to build. A file named `project_name.rb` must be present in the configs/projects/ directory.
+The name of the project to build. A file named `project_name.rb` must be present in the configs/projects directory.
 
 ### platform name
 
-The name of the platform to build for. A file named `platform_name.rb` must be present in the configs/platforms/ directory.
+The name of the platform to build for. A file named `platform_name.rb` must be present in the configs/platforms directory.
 
-You can specify multiple platforms to build for at once by using a comma-separated list (e.g, platform1,platform2).
+You can specify multiple platforms to build for at once by using a comma-separated list (`platform1,platform2` for example).
 
 ### target host [optional]
 
 Target host is an optional argument which overrides the host selection. Instead of using a vm collected from the pooler, the build will attempt to ssh to the target host as root.
 
-If you're building multiple platforms at once, multiple target hosts can also be specified using a comma-separated list (e.g, host1,host2). If fewer targets are specified than platforms, the default build engine (the pooler) will be used for platforms without a target host. If more target hosts are specified than platforms, the extra target hosts will be ignored.
+If you're building multiple platforms at once, multiple target hosts can also be specified using a comma-separated list (example: `host1,host2`). If fewer targets are specified than platforms, the default build engine (the pooler) will be used for platforms without a target host. If more target hosts are specified than platforms, the extra target hosts will be ignored.
 
-# Howto: Add a New Platform
+# How To Add a New Platform
 
 To add a new platform, begin by adding the platform definition file in configs/platforms. Then additional customizations when building components for that platform can be added to the component definitions in configs/components. If this is an entirely new platform (and not just a new version of a platform already supported), you may need to make changes in vanagon as well. Using the build dependency graph above, start with pl-gcc and work your way through the dependency chain. Once packages for all of the relevant pl-build-tools have been generated, you can then move on to building a puppet-agent package using the [puppet-agent](https://github.com/puppetlabs/puppet-agent) repository.
 
-# Howto: Add a New Project
+# How To Add a New Project
 
 New projects require an entry in `configs/projects`. A file for anything this project includes, with instructions on how to configure and build it, should also be added under `configs/components` if it does not already exists. Refer to existing projects in this repo or to [the example in vanagon](https://github.com/puppetlabs/vanagon/tree/master/examples) for more details.
 
 # Support
 
-Puppet, Inc. offers community-based support for this repository. Questions should be directed to the [Puppet Developers mailing list](https://groups.google.com/forum/#!forum/puppet-dev). Some code in this repository is related to platforms available only to Puppet Enterprise users, (e.g, Solaris and AIX), and we only offer support for those platforms to official partners of Puppet, Inc. 
+Puppet, Inc. offers community-based support for this repository. Questions should be directed to the [Puppet Developers mailing list](https://groups.google.com/forum/#!forum/puppet-dev). Some code in this repository is related to platforms available only to Puppet Enterprise users like Solaris and AIX; we only offer support for those platforms to official partners of Puppet, Inc.

--- a/configs/components/gcc.rb
+++ b/configs/components/gcc.rb
@@ -1,19 +1,18 @@
-component "gcc" do |pkg, settings, platform|
-  # Source-Related Metadata
-  if platform.name =~ /debian-9|el-7-aarch64|el-7-ppc64|sles-12-ppc64le|ubuntu-16\.04-ppc64el|ubuntu-18\.(04|10)/
-    pkg.version "6.1.0"
-    pkg.md5sum "8d04cbdfddcfad775fdbc5e112af2690"
-  elsif platform.is_aix? || platform.architecture =~ /arm/
-    pkg.version "5.2.0"
-    pkg.md5sum "1180e9ef7f5a2e4b1eab3e1a0d3fa228"
-  else
-    pkg.version "4.8.2"
-    pkg.md5sum "deca88241c1135e2ff9fa5486ab5957b"
-  end
-  pkg.url "http://ftp.gnu.org/gnu/gcc/gcc-#{pkg.get_version}/gcc-#{pkg.get_version}.tar.gz"
-  pkg.mirror "#{settings[:buildsources_url]}/gcc-#{pkg.get_version}.tar.gz"
+# See: https://gcc.gnu.org/install/prerequisites.html
 
-  pkg.apply_patch "resources/patches/gcc/aix-inclhack.patch" if platform.is_aix?
+component 'gcc' do |pkg, settings, platform|
+  gcc_version = settings[:gcc_version]
+
+  # Source-Related Metadata
+  if platform.is_aix? || platform.architecture.include?('arm')
+    pkg.md5sum '1180e9ef7f5a2e4b1eab3e1a0d3fa228'
+  else
+    pkg.md5sum 'd7644b494246450468464ffc2c2b19c3'
+  end
+
+  pkg.url "http://ftp.gnu.org/gnu/gcc/gcc-#{gcc_version}/gcc-#{gcc_version}.tar.gz"
+
+  pkg.apply_patch 'resources/patches/gcc/aix-inclhack.patch' if platform.is_aix?
 
   # glib 2.26 produces the following errors when building with gcc 5.y or 6.y:
   #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81712
@@ -24,17 +23,17 @@ component "gcc" do |pkg, settings, platform|
   #
   # On Linux, you can check the glib version by running `ldd --version`
   if platform.name =~ /ubuntu-18.(04|10)/
-    pkg.apply_patch "resources/patches/gcc/ucontext_t-linux-unwind_h.patch"
-    pkg.apply_patch "resources/patches/gcc/sanitizer_linux.patch"
+    pkg.apply_patch 'resources/patches/gcc/ucontext_t-linux-unwind_h.patch'
+    pkg.apply_patch 'resources/patches/gcc/sanitizer_linux.patch'
   end
 
   # Package Dependency Metadata
   if platform.is_linux?
-    pkg.requires "binutils"
+    pkg.requires 'binutils'
   end
 
   if platform.is_deb? || platform.is_cisco_wrlinux?
-    pkg.requires "libc6-dev"
+    pkg.requires 'libc6-dev'
   end
 
   if platform.is_solaris? && platform.os_version == "11"
@@ -49,58 +48,71 @@ component "gcc" do |pkg, settings, platform|
   # systems (other than AIX and SLES10)
   if platform.is_rpm?
     unless platform.is_aix?
-      pkg.build_requires "gcc"
-      pkg.build_requires "binutils"
-      pkg.build_requires "gzip"
-      pkg.build_requires "bzip2"
-      pkg.build_requires "make"
-      pkg.build_requires "tar"
+      pkg.build_requires 'gcc'
+      pkg.build_requires 'binutils'
+      pkg.build_requires 'gzip'
+      pkg.build_requires 'bzip2'
+      pkg.build_requires 'make'
+      pkg.build_requires 'tar'
     end
 
     case
     when platform.is_aix?
       # not version-specific for AIX
-      pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/gawk-3.1.3-1.aix5.1.ppc.rpm"
-      pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/gzip-1.2.4a-10.aix5.2.ppc.rpm"
-      pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/bzip2-1.0.5-3.aix5.3.ppc.rpm"
-      pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/make-3.80-1.aix5.1.ppc.rpm"
+      %w[
+        http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/gawk-3.1.3-1.aix5.1.ppc.rpm
+        http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/gzip-1.2.4a-10.aix5.2.ppc.rpm
+        http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/bzip2-1.0.5-3.aix5.3.ppc.rpm
+        http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/make-3.80-1.aix5.1.ppc.rpm
+      ].each do |aix_build_dependency|
+        pkg.build_requires aix_build_dependency
+      end
+
       if platform.os_version =~ /6.1|7.1/
-        pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/binutils-2.14-4.aix6.1.ppc.rpm"
-        pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/gcc-4.2.0-3.aix6.1.ppc.rpm"
-        pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/6.1/ppc/gcc-aix-bootstrap-4.6.4-1.aix6.1.ppc.rpm"
-        pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/libstdcplusplus-4.2.0-3.aix6.1.ppc.rpm"
-        pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/libstdcplusplus-devel-4.2.0-3.aix6.1.ppc.rpm"
-        pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/gcc-cplusplus-4.2.0-3.aix6.1.ppc.rpm"
-        pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/tar-1.22-1.aix6.1.ppc.rpm"
-        pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/libgcc-4.2.0-3.aix6.1.ppc.rpm"
+        %w[
+          http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/binutils-2.14-4.aix6.1.ppc.rpm
+          http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/gcc-4.2.0-3.aix6.1.ppc.rpm
+          http://pl-build-tools.delivery.puppetlabs.net/aix/6.1/ppc/gcc-aix-bootstrap-4.6.4-1.aix6.1.ppc.rpm
+          http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/libstdcplusplus-4.2.0-3.aix6.1.ppc.rpm
+          http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/libstdcplusplus-devel-4.2.0-3.aix6.1.ppc.rpm
+          http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/gcc-cplusplus-4.2.0-3.aix6.1.ppc.rpm
+          http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/tar-1.22-1.aix6.1.ppc.rpm
+          http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/libgcc-4.2.0-3.aix6.1.ppc.rpm
+        ].each do |aix_build_dependency|
+          pkg.build_requires aix_build_dependency
+        end
       else
         # AIX 5.3
-        pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/binutils-2.14-3.aix5.1.ppc.rpm"
-        pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/gcc-4.2.0-3.aix5.3.ppc.rpm"
-        pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/gcc-cplusplus-4.2.0-3.aix5.3.ppc.rpm"
-        pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/libstdcplusplus-4.2.0-3.aix5.3.ppc.rpm"
-        pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/libstdcplusplus-devel-4.2.0-3.aix5.3.ppc.rpm"
-        pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/tar-1.14-2.aix5.1.ppc.rpm"
-        pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/libgcc-4.2.0-3.aix5.3.ppc.rpm"
-        pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/5.3/ppc/gcc-aix-bootstrap-4.6.4-1.aix5.3.ppc.rpm"
+        %w[
+          http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/binutils-2.14-3.aix5.1.ppc.rpm
+          http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/gcc-4.2.0-3.aix5.3.ppc.rpm
+          http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/gcc-cplusplus-4.2.0-3.aix5.3.ppc.rpm
+          http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/libstdcplusplus-4.2.0-3.aix5.3.ppc.rpm
+          http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/libstdcplusplus-devel-4.2.0-3.aix5.3.ppc.rpm
+          http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/tar-1.14-2.aix5.1.ppc.rpm
+          http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/libgcc-4.2.0-3.aix5.3.ppc.rpm
+          http://pl-build-tools.delivery.puppetlabs.net/aix/5.3/ppc/gcc-aix-bootstrap-4.6.4-1.aix5.3.ppc.rpm
+        ].each do |aix_build_dependency|
+          pkg.build_requires aix_build_dependency
+        end
         # AIX 5.3 gcc464 is currently a tarball that should be built into an rpm
       end
     when platform.is_cisco_wrlinux?
-      pkg.build_requires "g++"
-      pkg.build_requires "libstdc++-dev"
-      pkg.build_requires "libc6-dev"
-    when platform.architecture == "ppc64le" || platform.architecture == "aarch64" || platform.architecture == "ppc64"
+      pkg.build_requires 'g++'
+      pkg.build_requires 'libstdc++-dev'
+      pkg.build_requires 'libc6-dev'
+    when %w[ppc64le aarch64 ppc64].include?(platform.architecture)
       pkg.build_requires "pl-binutils-#{platform.architecture}"
-      pkg.build_requires "sysroot"
-      pkg.build_requires "libstdc++-devel"
-      pkg.build_requires "gcc-c++"
+      pkg.build_requires 'sysroot'
+      pkg.build_requires 'libstdc++-devel'
+      pkg.build_requires 'gcc-c++'
     else
-      pkg.build_requires "libstdc++-devel"
-      pkg.build_requires "gcc-c++"
+      pkg.build_requires 'libstdc++-devel'
+      pkg.build_requires 'gcc-c++'
     end
   elsif platform.is_cross_compiled_linux?
     pkg.build_requires "pl-binutils-#{platform.architecture}"
-    pkg.build_requires "sysroot"
+    pkg.build_requires 'sysroot'
   elsif platform.is_solaris?
     if platform.os_version == '10'
       pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-binutils-2.27-1.#{platform.architecture}.pkg.gz"
@@ -108,7 +120,7 @@ component "gcc" do |pkg, settings, platform|
       pkg.build_requires "pl-binutils-#{platform.architecture}"
     end
     if platform.architecture.downcase == 'sparc'
-      pkg.build_requires "sysroot"
+      pkg.build_requires 'sysroot'
     end
   end
 
@@ -116,50 +128,51 @@ component "gcc" do |pkg, settings, platform|
   if platform.is_aix?
     # AIX can't use the exact flags that linux does, but we should still
     # attempt to honor any flags passed via environment variables.
-    pkg.environment "CFLAGS"   => "$${CFLAGS}"
-    pkg.environment "CXXFLAGS" => "$${CXXFLAGS}"
+    pkg.environment('CFLAGS', '$${CFLAGS}')
+    pkg.environment('CXXFLAGS', '$${CXXFLAGS}')
   elsif platform.is_cross_compiled_linux?
     # Without this, libstdc++ and libssp get built with a dependency on
     # libgcc_s, but with no way to find it.
-    pkg.environment "LDFLAGS_FOR_TARGET" => "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
+    pkg.environment('LDFLAGS_FOR_TARGET', '-Wl,-rpath=/opt/puppetlabs/puppet/lib')
     # Do not use fPIC with the cross-compiler.
-    pkg.environment "CFLAGS" => "$${CFLAGS}"
-    pkg.environment "CXXFLAGS" => "$${CXXFLAGS}"
+    pkg.environment('CFLAGS', '$${CFLAGS}')
+    pkg.environment('CXXFLAGS', '$${CXXFLAGS}')
   elsif platform.is_solaris?
     # Solaris needs an augmented path to find binutils correctly and to setup CC and CXX
-    pkg.environment "PATH"  => "#{File.join(settings[:basedir], 'bin')}:#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$$PATH"
-    pkg.environment "CC"    => "/usr/sfw/bin/gcc"
-    pkg.environment "CXX"   => "/usr/sfw/bin/g++"
+    pkg.environment('PATH', "#{File.join(settings[:basedir], 'bin')}:#{settings[:bindir]}:" \
+                            "/usr/ccs/bin:/usr/sfw/bin:$$PATH")
+    pkg.environment('CC', '/usr/sfw/bin/gcc')
+    pkg.environment('CXX', '/usr/sfw/bin/g++')
 
     # Without this, libstdc++ and libssp get built with a dependency on
     # libgcc_s, but with no way to find it.
-    pkg.environment "LDFLAGS_FOR_TARGET" => "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
+    pkg.environment('LDFLAGS_FOR_TARGET', '-Wl,-rpath=/opt/puppetlabs/puppet/lib')
 
     # Adding -fPIC to the cross-compiler produces a cross-compiler that can't
     # build executables. They all core dump and segfault. Do not use fPIC with
     # the cross-compiler.
-    if platform.architecture == "sparc"
-      pkg.environment "CFLAGS" => "$${CFLAGS}"
-      pkg.environment "CXXFLAGS" => "$${CXXFLAGS}"
+    if platform.architecture == 'sparc'
+      pkg.environment('CFLAGS', '$${CFLAGS}')
+      pkg.environment('CXXFLAGS', '$${CXXFLAGS}')
     else
-      pkg.environment "CFLAGS" => "$${CFLAGS} -fPIC"
-      pkg.environment "CXXFLAGS" => "$${CXXFLAGS} -fPIC"
-      pkg.environment "CFLAGS_FOR_TARGET" => "-fPIC"
+      pkg.environment('CFLAGS', '$${CFLAGS} -fPIC')
+      pkg.environment('CXXFLAGS', '$${CXXFLAGS} -fPIC')
+      pkg.environment('CFLAGS_FOR_TARGET', '-fPIC')
     end
   else
     # We set -fPIC to ensure that our 64 bit builds can correctly link and compile.
     # We enable it on both 32-bit and 64-bit builds for consistency.
-    pkg.environment "CFLAGS" => "$${CFLAGS} -fPIC"
-    pkg.environment "CXXFLAGS" => "$${CXXFLAGS} -fPIC"
-    pkg.environment "CFLAGS_FOR_TARGET" => "-fPIC"
+    pkg.environment('CFLAGS', '$${CFLAGS} -fPIC')
+    pkg.environment('CXXFLAGS','$${CXXFLAGS} -fPIC')
+    pkg.environment('CFLAGS_FOR_TARGET', '-fPIC')
 
     # Without this, libstdc++ and libssp get built with a dependency on
     # libgcc_s, but with no way to find it.
-    pkg.environment "LDFLAGS_FOR_TARGET" => "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
+    pkg.environment('LDFLAGS_FOR_TARGET', '-Wl,-rpath=/opt/puppetlabs/puppet/lib')
   end
 
-  # Initialize an empty configure_command string
-  configure_command = ""
+
+  configure_steps = ''
 
   #  Some notes on AIX.
   #    AIX ships with gcc-4.2.4. We want 4.8.2 or higher. To get to 4.8.2 you
@@ -169,16 +182,16 @@ component "gcc" do |pkg, settings, platform|
   #    http://pl-build-tools.delivery.puppetlabs.net/aix/6.1/ppc/ for
   #    booststrapping GCC.
   if platform.is_aix?
-    configure_command << "export CC=/opt/gcc464/bin/gcc; export CXX=/opt/gcc464/bin/g++; "
+    configure_steps << 'export CC=/opt/gcc464/bin/gcc; export CXX=/opt/gcc464/bin/g++; '
     # AIX needs higher ulimit parameters to build GCC
-    configure_command << " ulimit -s 2560000; ulimit -d 2048575; "
-    configure_command << " chsec -f /etc/security/limits -s default -a stack=2560000;"
-    configure_command << " chsec -f /etc/security/limits -s default -a data=2560000;"
+    configure_steps << ' ulimit -s 2560000; ulimit -d 2048575; '
+    configure_steps << ' chsec -f /etc/security/limits -s default -a stack=2560000;'
+    configure_steps << ' chsec -f /etc/security/limits -s default -a data=2560000;'
   end
 
   # We've abstracted the configure command a bit because of the difference in
   # flags needed for ARM vs x86 and x86_64 vs AIX/ppc
-  configure_command << " ../gcc-#{pkg.get_version}/configure \
+  configure_steps << " ../gcc-#{gcc_version}/configure \
     --prefix=#{settings[:basedir]} \
     --disable-nls \
     --enable-languages=c,c++ \
@@ -187,8 +200,8 @@ component "gcc" do |pkg, settings, platform|
 
   # On the ARM Debian builds, you actually need multilib, so we'll exclude this
   # exclude flag on ARM.
-  unless platform.architecture =~ /arm/i or platform.is_solaris?
-    configure_command << " --disable-multilib"
+  unless platform.architecture =~ /arm/i || platform.is_solaris?
+    configure_steps << ' --disable-multilib'
   end
 
   # The arm flags were taken from the Debian GCC compile options. (gcc -v)
@@ -197,11 +210,11 @@ component "gcc" do |pkg, settings, platform|
   # The other flags are to instruct GCC on the proper target to look at in
   # libgcc when linking.
   if platform.architecture =~ /arm/i
-    configure_command << " --with-arch-directory=arm \ "
-    if platform.architecture == "armhf"
-      configure_command << " --with-fpu=vfp --with-float=hard \ "
+    configure_steps << ' --with-arch-directory=arm \ '
+    if platform.architecture == 'armhf'
+      configure_steps << ' --with-fpu=vfp --with-float=hard \ '
     else
-      configure_command << "--with-arch=armv4t --with-float=soft  \ "
+      configure_steps << '--with-arch=armv4t --with-float=soft  \ '
     end
   end
 
@@ -211,14 +224,15 @@ component "gcc" do |pkg, settings, platform|
   # configuration of gcc.
   # On AIX 5.3 it's powerpc-ibm-aix5.3.0.0
   if platform.is_aix?
-    if platform.os_version == '5.3'
-      target_platform = "powerpc-ibm-aix5.3.0.0"
-    elsif platform.os_version == '6.1'
-      target_platform = "powerpc-ibm-aix6.1.0.0"
-    else
-      target_platform = "powerpc-ibm-aix7.1.0.0"
-    end
-    configure_command << " --with-as=/usr/bin/as \
+    target_platform = case platform.os_version
+                      when '5.3'
+                        'powerpc-ibm-aix5.3.0.0'
+                      when '6.1'
+                        'powerpc-ibm-aix6.1.0.0'
+                      else
+                        'powerpc-ibm-aix7.1.0.0'
+                      end
+    configure_steps << " --with-as=/usr/bin/as \
     --with-ld=/usr/bin/ld \
     --enable-threads \
     --enable-version-specific-runtime-libs \
@@ -229,45 +243,45 @@ component "gcc" do |pkg, settings, platform|
   end
 
   if platform.is_cross_compiled_linux?
-    configure_command << " --target=#{settings[:platform_triple]} \
+    configure_steps << " --target=#{settings[:platform_triple]} \
       --with-sysroot=#{settings[:prefix]}/sysroot"
   end
 
   if platform.is_solaris?
-    configure_command << " --target=#{settings[:platform_triple]} \
+    configure_steps << " --target=#{settings[:platform_triple]} \
       --with-gnu-as \
       --with-as=#{settings[:bindir]}/as \
       --with-gnu-ld \
       --with-ld=#{settings[:bindir]}/ld"
 
       if platform.architecture.downcase == 'sparc'
-        configure_command << " --with-sysroot=#{settings[:prefix]}/sysroot"
+        configure_steps << " --with-sysroot=#{settings[:prefix]}/sysroot"
       end
   end
 
   # Build Commands
   pkg.configure do
     [
-      #TODO figure out a better way to find the version number than hard-code it
-      'ln -s ../gmp-4.3.2 gmp',
-      'ln -s ../mpc-1.0.3 mpc',
-      'ln -s ../mpfr-2.4.2 mpfr',
+      "ln -s ../gmp-#{settings[:gmp_version]} gmp",
+      "ln -s ../mpc-#{settings[:mpc_version]} mpc",
+      "ln -s ../mpfr-#{settings[:mpfr_version]} mpfr",
       'mkdir -p ../obj-gcc-build-dir',
       'cd ../obj-gcc-build-dir',
-      configure_command,
+      configure_steps
     ]
   end
 
+
   pkg.build do
     [
-      "cd ../obj-gcc-build-dir",
+      'cd ../obj-gcc-build-dir',
       "#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"
     ]
   end
 
   pkg.install do
     [
-      "cd ../obj-gcc-build-dir",
+      'cd ../obj-gcc-build-dir',
       "#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install",
     ]
   end

--- a/configs/components/gmp.rb
+++ b/configs/components/gmp.rb
@@ -1,7 +1,6 @@
-# This is here just for the downloading and unpacking
-component "gmp" do |pkg, settings, platform|
-  pkg.version "4.3.2"
-  pkg.md5sum "2a431d487dfd76d0f618d241b1e551cc"
-  pkg.url "http://ftp.gnu.org/gnu/gmp/gmp-#{pkg.get_version}.tar.gz"
-  pkg.mirror "#{settings[:buildsources_url]}/gmp-#{pkg.get_version}.tar.gz"
+# https://gmplib.org
+component 'gmp' do |pkg, settings, _platform|
+  pkg.version settings[:gmp_version]
+  pkg.md5sum '0b82665c4a92fd2ade7440c13fcaa42b'
+  pkg.url "http://ftp.gnu.org/gnu/gmp/gmp-#{pkg.get_version}.tar.xz"
 end

--- a/configs/components/mpc.rb
+++ b/configs/components/mpc.rb
@@ -1,7 +1,6 @@
-# This is here just for the downloading and unpacking
-component "mpc" do |pkg, settings, platform|
-  pkg.version "1.0.3"
-  pkg.md5sum "d6a1d5f8ddea3abd2cc3e98f58352d26"
+# https://directory.fsf.org/wiki/Mpc
+component 'mpc' do |pkg, settings, _platform|
+  pkg.version settings[:mpc_version]
+  pkg.md5sum '2f1ce56ac775f2be090863f364931a03'
   pkg.url "http://ftp.gnu.org/gnu/mpc/mpc-#{pkg.get_version}.tar.gz"
-  pkg.mirror "#{settings[:buildsources_url]}/mpc-#{pkg.get_version}.tar.gz"
 end

--- a/configs/components/mpfr.rb
+++ b/configs/components/mpfr.rb
@@ -1,7 +1,9 @@
+##
+# GNU MPFR (https://www.mpfr.org) C library for multiple-precision floating-point computations
+
 # This is here just for the downloading and unpacking
-component "mpfr" do |pkg, settings, platform|
-  pkg.version "2.4.2"
-  pkg.md5sum "0e3dcf9fe2b6656ed417c89aa9159428"
+component 'mpfr' do |pkg, settings, _platform|
+  pkg.version settings[:mpfr_version]
+  pkg.md5sum '81a97a9ba03590f83a30d26d4400ce39'
   pkg.url "http://ftp.gnu.org/gnu/mpfr/mpfr-#{pkg.get_version}.tar.gz"
-  pkg.mirror "#{settings[:buildsources_url]}/mpfr-#{pkg.get_version}.tar.gz"
 end

--- a/configs/platforms/el-7-x86_64.rb
+++ b/configs/platforms/el-7-x86_64.rb
@@ -1,3 +1,3 @@
-platform "el-7-x86_64" do |plat|
+platform 'el-7-x86_64' do |plat|
   plat.inherit_from_default
 end

--- a/configs/platforms/sles-12-x86_64.rb
+++ b/configs/platforms/sles-12-x86_64.rb
@@ -1,3 +1,3 @@
-platform "sles-12-x86_64" do |plat|
+platform 'sles-12-x86_64' do |plat|
   plat.inherit_from_default
 end

--- a/configs/projects/pl-gcc.rb
+++ b/configs/projects/pl-gcc.rb
@@ -26,8 +26,10 @@ project 'pl-gcc' do |proj|
 
   # Platform specific - these flags do not work on AIX
   unless platform.is_aix?
+    libdir =  '/opt/pl-build-tools/lib64'
+    proj.setting(:libdir, libdir)
     proj.setting(:cflags, "-I#{proj.includedir}")
-    proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir}")
+    proj.setting(:ldflags, "-L#{libdir} -Wl,-rpath=#{libdir}")
   end
 
   # https://gmplib.org

--- a/configs/projects/pl-gcc.rb
+++ b/configs/projects/pl-gcc.rb
@@ -1,28 +1,28 @@
-project "pl-gcc" do |proj|
+project 'pl-gcc' do |proj|
   # Project level settings our components will care about
   instance_eval File.read('configs/projects/pl-build-tools.rb')
 
-  proj.description "Puppet Labs GCC"
+  proj.description 'Puppet Labs GCC'
 
-  if platform.name =~ /debian-9|el-7-aarch64|el-7-ppc64|sles-12-ppc64le|ubuntu-16\.04-ppc64el|ubuntu-18\.(04|10)/
-    proj.version "6.1.0"
-    proj.release "6"
-  elsif platform.is_aix? || platform.architecture =~ /arm/
-    proj.version "5.2.0"
-    proj.release "11"
+  if platform.is_aix? || platform.architecture =~ /arm/
+    gcc_version = '5.2.0'
+    proj.release '11'
   else
-    proj.version "4.8.2"
-    proj.release "9"
+    gcc_version = '12.2.0'
+    proj.release '0'
   end
+
+  proj.version gcc_version
+  proj.setting(:gcc_version, gcc_version)
 
   if platform.is_cross_compiled?
     proj.name "pl-gcc-#{platform.architecture}"
     proj.noarch
   end
 
-  proj.license "Same as GCC"
-  proj.vendor "Puppet Labs <info@puppetlabs.com>"
-  proj.homepage "https://www.puppetlabs.com"
+  proj.license 'Same as GCC'
+  proj.vendor 'Puppet Labs <info@puppet.com>'
+  proj.homepage 'https://www.puppet.com'
 
   # Platform specific - these flags do not work on AIX
   unless platform.is_aix?
@@ -30,14 +30,23 @@ project "pl-gcc" do |proj|
     proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir}")
   end
 
-  proj.component "gmp"
-  proj.component "mpfr"
-  proj.component "mpc"
-  proj.component "gcc"
+  # https://gmplib.org
+  proj.setting(:gmp_version, '6.2.1')
+  proj.component 'gmp'
+
+  # https://www.mpfr.org
+  proj.setting(:mpfr_version, '4.1.0')
+  proj.component 'mpfr'
+
+  # https://directory.fsf.org/wiki/Mpc
+  proj.setting(:mpc_version, '1.2.0')
+  proj.component 'mpc'
+
+  proj.component 'gcc'
 
   if platform.is_cross_compiled?
-    proj.component "sysroot"
+    proj.component 'sysroot'
   end
 
-  proj.target_repo ""
+  proj.target_repo ''
 end


### PR DESCRIPTION
Mostly for the benefit of creating Java 17 for el-7 and sles-12, we
need a GCC compiler >= 5.5