### PR TITLE
(maint) Patch CMake for OpenSSL 3

### DIFF
--- a/configs/components/cmake.rb
+++ b/configs/components/cmake.rb
@@ -12,6 +12,12 @@ component "cmake" do |pkg, settings, platform|
     pkg.apply_patch 'resources/patches/cmake/use-g++-as-linker-solaris.patch'
   end
 
+  # Remove these if/when bumping to CMake 3.18 or above
+  pkg.apply_patch 'resources/patches/cmake/0001-FindOpenSSL-Tolerate-tabs-in-header-while-parsing-ve.patch'
+  pkg.apply_patch 'resources/patches/cmake/0002-FindOpenSSL-Do-not-assume-that-the-version-regex-fin.patch'
+  pkg.apply_patch 'resources/patches/cmake/0003-FindOpenSSL-Detect-OpenSSL-3.0.0.patch'
+  pkg.apply_patch 'resources/patches/cmake/0004-FindOpenSSL-Fix-OpenSSL-3.0.0-version-extraction.patch'
+
   # Package Dependency Metadata
 
   # Build Requirements

--- a/configs/components/toolchain.rb
+++ b/configs/components/toolchain.rb
@@ -9,6 +9,7 @@ component "toolchain" do |pkg, settings, platform|
       pkg.add_source "file://files/cmake/el-ppc64le-toolchain.cmake"
       pkg.add_source "file://files/cmake/sles-ppc64le-toolchain.cmake"
       pkg.add_source "file://files/cmake/el-aarch64-toolchain.cmake"
+    end
   elsif platform.is_aix?
     pkg.version "2015.10.01"
     # Despite the name, this toolchain applies to all aix versions
@@ -58,5 +59,6 @@ component "toolchain" do |pkg, settings, platform|
       pkg.install_file "el-ppc64le-toolchain.cmake", "#{settings[:basedir]}/ppc64le-redhat-linux/pl-build-toolchain.cmake"
       pkg.install_file "sles-ppc64le-toolchain.cmake", "#{settings[:basedir]}/powerpc64le-suse-linux/pl-build-toolchain.cmake"
       pkg.install_file "el-aarch64-toolchain.cmake", "#{settings[:basedir]}/aarch64-redhat-linux/pl-build-toolchain.cmake"
+    end
   end
 end

--- a/configs/projects/pl-cmake.rb
+++ b/configs/projects/pl-cmake.rb
@@ -4,7 +4,7 @@ project "pl-cmake" do |proj|
 
   proj.description "Puppet Labs cmake"
   proj.version "3.2.3"
-  proj.release "19"
+  proj.release "20"
 
   proj.license "BSD"
   proj.vendor "Puppet Labs <info@puppetlabs.com>"

--- a/resources/patches/cmake/0001-FindOpenSSL-Tolerate-tabs-in-header-while-parsing-ve.patch
+++ b/resources/patches/cmake/0001-FindOpenSSL-Tolerate-tabs-in-header-while-parsing-ve.patch
@@ -1,0 +1,29 @@
+From 6962c466e5a02c4b8a7b7db7645e2403c01bb76c Mon Sep 17 00:00:00 2001
+From: Wayne Stambaugh <stambaughw@gmail.com>
+Date: Sat, 3 Oct 2015 11:40:00 -0400
+Subject: [PATCH 1/4] FindOpenSSL: Tolerate tabs in header while parsing
+ version (#15765)
+
+Tolerate tabs instead of spaces in the "# define" line.
+
+(cherry picked from commit 6b575dec8d393c4a38c587ee97afa068eeb4b432)
+---
+ Modules/FindOpenSSL.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Modules/FindOpenSSL.cmake b/Modules/FindOpenSSL.cmake
+index 3adc269262..b97db51866 100644
+--- a/Modules/FindOpenSSL.cmake
++++ b/Modules/FindOpenSSL.cmake
+@@ -285,7 +285,7 @@ endfunction()
+ if (OPENSSL_INCLUDE_DIR)
+   if(OPENSSL_INCLUDE_DIR AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h")
+     file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" openssl_version_str
+-         REGEX "^# *define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])+.*")
++         REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])+.*")
+ 
+     # The version number is encoded as 0xMNNFFPPS: major minor fix patch status
+     # The status gives if this is a developer or prerelease and is ignored here.
+-- 
+2.25.1
+

--- a/resources/patches/cmake/0002-FindOpenSSL-Do-not-assume-that-the-version-regex-fin.patch
+++ b/resources/patches/cmake/0002-FindOpenSSL-Do-not-assume-that-the-version-regex-fin.patch
@@ -1,0 +1,36 @@
+From 962b338e9dae4a41c05fb0804d077e6ee2396346 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Vladim=C3=ADr=20Vondru=C5=A1?= <mosra@centrum.cz>
+Date: Thu, 9 Jun 2016 14:03:47 +0200
+Subject: [PATCH 2/4] FindOpenSSL: Do not assume that the version regex finds
+ something
+
+BoringSSL's openslv.h does not have the version information.
+
+(cherry picked from commit e937b4c3879e1ee0770b465c0cdcbb6a960ba892)
+---
+ Modules/FindOpenSSL.cmake | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Modules/FindOpenSSL.cmake b/Modules/FindOpenSSL.cmake
+index b97db51866..3fc398bd9f 100644
+--- a/Modules/FindOpenSSL.cmake
++++ b/Modules/FindOpenSSL.cmake
+@@ -282,11 +282,11 @@ function(from_hex HEX DEC)
+   set(${DEC} ${_res} PARENT_SCOPE)
+ endfunction()
+ 
+-if (OPENSSL_INCLUDE_DIR)
+-  if(OPENSSL_INCLUDE_DIR AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h")
+-    file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" openssl_version_str
+-         REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])+.*")
++if(OPENSSL_INCLUDE_DIR AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h")
++  file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" openssl_version_str
++       REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])+.*")
+ 
++  if(openssl_version_str)
+     # The version number is encoded as 0xMNNFFPPS: major minor fix patch status
+     # The status gives if this is a developer or prerelease and is ignored here.
+     # Major, minor, and fix directly translate into the version numbers shown in
+-- 
+2.25.1
+

--- a/resources/patches/cmake/0003-FindOpenSSL-Detect-OpenSSL-3.0.0.patch
+++ b/resources/patches/cmake/0003-FindOpenSSL-Detect-OpenSSL-3.0.0.patch
@@ -1,0 +1,42 @@
+From fd17a0add77dac9ffda5307604c6f6b87ddf2875 Mon Sep 17 00:00:00 2001
+From: Vitezslav Cizek <vcizek@suse.com>
+Date: Wed, 27 May 2020 14:52:17 +0200
+Subject: [PATCH 3/4] FindOpenSSL: Detect OpenSSL 3.0.0
+
+The OpenSSL versioning is changing with the upcoming 3.0.0 release.
+https://www.openssl.org/blog/blog/2018/11/28/version/
+Since 3.0.0, the patch letters are being dropped. The new format is:
+MAJOR.MINOR.PATCH
+
+The OPENSSL_VERSION variable can now be directly derived from the new
+OPENSSL_VERSION_STR macro.
+https://www.openssl.org/docs/manmaster/man3/OPENSSL_VERSION_NUMBER.html
+
+(cherry picked from commit 61d746e5922de50310558364f157b261f3e7917a)
+---
+ Modules/FindOpenSSL.cmake | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/Modules/FindOpenSSL.cmake b/Modules/FindOpenSSL.cmake
+index 3fc398bd9f..1432d2f4c5 100644
+--- a/Modules/FindOpenSSL.cmake
++++ b/Modules/FindOpenSSL.cmake
+@@ -315,6 +315,15 @@ if(OPENSSL_INCLUDE_DIR AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h")
+     endif ()
+ 
+     set(OPENSSL_VERSION "${OPENSSL_VERSION_MAJOR}.${OPENSSL_VERSION_MINOR}.${OPENSSL_VERSION_FIX}${OPENSSL_VERSION_PATCH_STRING}")
++  else ()
++    # Since OpenSSL 3.0.0, the new version format is MAJOR.MINOR.PATCH and
++    # a new OPENSSL_VERSION_STR macro contains exactly that
++    file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" OPENSSL_VERSION_STR
++         REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_STR[\t ]+\"([0-9])+\.([0-9])+\.([0-9])+\".*")
++    string(REGEX REPLACE "^.*OPENSSL_VERSION_STR[\t ]+\"([0-9]+\.[0-9]+\.[0-9]+)\".*$"
++           "\\1" OPENSSL_VERSION_STR "${OPENSSL_VERSION_STR}")
++
++    set(OPENSSL_VERSION "${OPENSSL_VERSION_STR}")
+   endif ()
+ endif ()
+ 
+-- 
+2.25.1
+

--- a/resources/patches/cmake/0004-FindOpenSSL-Fix-OpenSSL-3.0.0-version-extraction.patch
+++ b/resources/patches/cmake/0004-FindOpenSSL-Fix-OpenSSL-3.0.0-version-extraction.patch
@@ -1,0 +1,39 @@
+From 433ec42c8af1e519000521a7dfab9bbdf7b2c701 Mon Sep 17 00:00:00 2001
+From: Billy Brumley <bbrumley@gmail.com>
+Date: Sat, 6 Jun 2020 10:31:59 +0300
+Subject: [PATCH 4/4] FindOpenSSL: Fix OpenSSL 3.0.0 version extraction
+
+Fix the regex syntax added by commit 61d746e592 (FindOpenSSL: Detect
+OpenSSL 3.0.0, 2020-05-27, v3.17.3~1^2).  Add missing escapes.
+Test with `openssl-3.0.0-alpha3`.
+
+While at it, also unset a temporary variable after use.
+
+(cherry picked from commit 796b447373ea8b085a8e41903dacdf9cc27f171a)
+---
+ Modules/FindOpenSSL.cmake | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/Modules/FindOpenSSL.cmake b/Modules/FindOpenSSL.cmake
+index 1432d2f4c5..fd5a051490 100644
+--- a/Modules/FindOpenSSL.cmake
++++ b/Modules/FindOpenSSL.cmake
+@@ -319,11 +319,13 @@ if(OPENSSL_INCLUDE_DIR AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h")
+     # Since OpenSSL 3.0.0, the new version format is MAJOR.MINOR.PATCH and
+     # a new OPENSSL_VERSION_STR macro contains exactly that
+     file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" OPENSSL_VERSION_STR
+-         REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_STR[\t ]+\"([0-9])+\.([0-9])+\.([0-9])+\".*")
+-    string(REGEX REPLACE "^.*OPENSSL_VERSION_STR[\t ]+\"([0-9]+\.[0-9]+\.[0-9]+)\".*$"
++         REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_STR[\t ]+\"([0-9])+\\.([0-9])+\\.([0-9])+\".*")
++    string(REGEX REPLACE "^.*OPENSSL_VERSION_STR[\t ]+\"([0-9]+\\.[0-9]+\\.[0-9]+)\".*$"
+            "\\1" OPENSSL_VERSION_STR "${OPENSSL_VERSION_STR}")
+ 
+     set(OPENSSL_VERSION "${OPENSSL_VERSION_STR}")
++
++    unset(OPENSSL_VERSION_STR)
+   endif ()
+ endif ()
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
OpenSSL changed their versioning scheme in 3.0, which breaks CMake's FindOpenSSL.

Building https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1975/