### PR TITLE
(maint) delete obsolete 'gpg_name'

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,6 +1,5 @@
 ---
 project: 'pl-build-tools'
-gpg_name: 'info@puppetlabs.com'
 sign_tar: FALSE
 vanagon_project: TRUE
 build_tar: FALSE


### PR DESCRIPTION
Delete obsolete build_defaults.yaml setting 'gpg_name'